### PR TITLE
Add DEFAULT_BASE_URL; make API_URL optional

### DIFF
--- a/overmind/__init__.py
+++ b/overmind/__init__.py
@@ -6,7 +6,7 @@ Overmind: automatic observability for LLM applications.
 
 """
 
-__version__ = "0.1.41"
+__version__ = "0.1.46"
 
 from opentelemetry.overmind.prompt import PromptString
 

--- a/overmind/client.py
+++ b/overmind/client.py
@@ -43,6 +43,7 @@ from uuid import UUID
 
 import tomlkit
 
+from overmind.core.constants import DEFAULT_BASE_URL
 from overmind.openapi_client import ApiClient, Configuration
 from overmind.openapi_client.api.agents_api import AgentsApi
 from overmind.openapi_client.api.auth_api import AuthApi
@@ -239,11 +240,18 @@ class OvermindClient(
 
 
 def get_client() -> OvermindClient | None:
-    """Return a configured client if ``OVERMIND_API_URL`` and ``OVERMIND_API_KEY`` are set."""
-    base_url = os.getenv("OVERMIND_API_URL", "").strip().rstrip("/")
+    """Return a configured client if ``OVERMIND_API_KEY`` is set.
+
+    ``OVERMIND_API_URL`` is optional: when unset, it falls back to
+    :data:`overmind.core.constants.DEFAULT_BASE_URL` (the Overmind Cloud
+    endpoint), mirroring the behaviour of :mod:`overmind.tracing`.
+    Self-hosted deployments override the default by setting
+    ``OVERMIND_API_URL`` explicitly.
+    """
+    base_url = (os.getenv("OVERMIND_API_URL", "").strip() or DEFAULT_BASE_URL).rstrip("/")
     token = os.getenv("OVERMIND_API_KEY", "").strip()
-    if not base_url or not token:
-        logger.debug(f"get_client: API not configured (base_url_set={bool(base_url)} token_set={bool(token)})")
+    if not token:
+        logger.debug("get_client: API not configured (OVERMIND_API_KEY not set)")
         return None
     cfg = Configuration(host=base_url, api_key=token)
     cfg.access_token = token
@@ -253,8 +261,13 @@ def get_client() -> OvermindClient | None:
 
 
 def is_configured() -> bool:
-    """Return True if both ``OVERMIND_API_URL`` and ``OVERMIND_API_KEY`` are set."""
-    return bool(os.getenv("OVERMIND_API_URL", "").strip() and os.getenv("OVERMIND_API_KEY", "").strip())
+    """Return True if ``OVERMIND_API_KEY`` is set.
+
+    ``OVERMIND_API_URL`` is optional — :func:`get_client` falls back to the
+    Overmind Cloud default when it is unset — so the control-plane client is
+    considered configured as soon as a bearer token is present.
+    """
+    return bool(os.getenv("OVERMIND_API_KEY", "").strip())
 
 
 def get_project_id() -> str | None:

--- a/overmind/core/constants.py
+++ b/overmind/core/constants.py
@@ -1,9 +1,18 @@
-"""Shared filesystem constants for Overmind state under the project root."""
+"""Shared constants for Overmind: filesystem layout and backend defaults."""
 
 from __future__ import annotations
 
 # Directory created by ``overmind init``; its presence marks the project root.
 OVERMIND_DIR_NAME = ".overmind"
+
+# Default Overmind Cloud backend URL.
+#
+# Used as a fallback when ``OVERMIND_API_URL`` is not set in the environment,
+# so that both the tracing exporter (``overmind.tracing``) and the control-plane
+# client (``overmind.client``) behave consistently for cloud users who only
+# configure ``OVERMIND_API_KEY``. Self-hosted deployments override this by
+# setting ``OVERMIND_API_URL`` explicitly.
+DEFAULT_BASE_URL = "https://api.overmindlab.ai"
 
 
 def overmind_rel(*segments: str) -> str:

--- a/overmind/storage/__init__.py
+++ b/overmind/storage/__init__.py
@@ -30,12 +30,14 @@ Configuration
 -------------
 ``get_storage()`` requires the standard Overmind environment variables:
 
-* ``OVERMIND_API_URL``  — backend base URL.
-* ``OVERMIND_API_KEY`` — bearer token.
+* ``OVERMIND_API_KEY`` — bearer token (required).
+* ``OVERMIND_API_URL`` — backend base URL.  Optional; defaults to
+  :data:`overmind.core.constants.DEFAULT_BASE_URL` (Overmind Cloud) when
+  unset. Set this only when targeting a self-hosted backend.
 * ``OVERMIND_PROJECT_ID`` — project the agent belongs to (only required
   when creating a new agent record).
 
-If either of the first two is missing, :func:`get_storage` raises
+If ``OVERMIND_API_KEY`` is missing, :func:`get_storage` raises
 :class:`StorageNotConfiguredError`.
 """
 
@@ -52,7 +54,11 @@ from overmind.storage.base import StorageBackend
 
 
 class StorageNotConfiguredError(RuntimeError):
-    """Raised when ``OVERMIND_API_URL`` / ``OVERMIND_API_KEY`` are not set."""
+    """Raised when ``OVERMIND_API_KEY`` is not set.
+
+    ``OVERMIND_API_URL`` is optional: when unset, the control-plane client
+    falls back to :data:`overmind.core.constants.DEFAULT_BASE_URL`.
+    """
 
 
 @dataclass
@@ -125,16 +131,18 @@ def get_storage() -> StorageBackend:
     Raises
     ------
     StorageNotConfiguredError
-        If ``OVERMIND_API_URL`` or ``OVERMIND_API_KEY`` is not set.
+        If ``OVERMIND_API_KEY`` is not set.  ``OVERMIND_API_URL`` is
+        optional and defaults to the Overmind Cloud endpoint.
     ValueError
         If no agent path can be resolved (neither bound nor in env).
     """
     load_overmind_dotenv()
     if not is_configured():
         raise StorageNotConfiguredError(
-            "Overmind API is not configured. Set OVERMIND_API_URL and "
-            "OVERMIND_API_KEY (in .overmind/.env or process env) before "
-            "calling get_storage()."
+            "Overmind API is not configured. Set OVERMIND_API_KEY "
+            "(and optionally OVERMIND_API_URL to override the cloud default) "
+            "in .overmind/.env or the process environment before calling "
+            "get_storage()."
         )
 
     bound = _BOUND_STORAGE.get()

--- a/overmind/tracing.py
+++ b/overmind/tracing.py
@@ -45,6 +45,7 @@ from opentelemetry.trace import Status, StatusCode
 from rich.console import Console
 
 from overmind import attrs
+from overmind.core.constants import DEFAULT_BASE_URL
 from overmind.utils.io import read_api_key_masked
 
 logger = logging.getLogger(__name__)
@@ -63,7 +64,9 @@ console = Console()
 # utility functions
 # ---------------------------------------------------------------------------
 
-DEFAULT_BASE_URL = "https://api.overmindlab.ai"
+# ``DEFAULT_BASE_URL`` is re-exported above from ``overmind.core.constants`` so
+# external imports (``from overmind.tracing import DEFAULT_BASE_URL``) continue
+# to resolve. Edit the canonical value in ``overmind/core/constants.py``.
 
 
 def get_api_settings(


### PR DESCRIPTION
Introduce DEFAULT_BASE_URL (https://api.overmindlab.ai) in overmind.core.constants and re-export it from tracing. Change client.get_client and is_configured to treat OVERMIND_API_URL as optional (falling back to DEFAULT_BASE_URL) and require only OVERMIND_API_KEY; update logging accordingly. Update storage docs and StorageNotConfiguredError message to reflect that only OVERMIND_API_KEY is required and OVERMIND_API_URL is optional. Bump package version to 0.1.46.