### PR TITLE
fix custom model error

### DIFF
--- a/overmind/tracing.py
+++ b/overmind/tracing.py
@@ -240,6 +240,12 @@ class _GenAiUsageSpanProcessor(SpanProcessor):
         return
 
     def on_end(self, span) -> None:
+        try:
+            self.patch_on_end(span)
+        except Exception:
+            logger.debug("genai enrichment could not set attributes", exc_info=True)
+
+    def patch_on_end(self, span) -> None:
         updates = canonical_usage_updates(span.attributes or {})
         if not updates:
             return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ name = "overmind"
 readme = "README.md"
 requires-python = ">=3.10,<4" # todo; remove the upper bound
 urls = { Homepage = "https://github.com/overmind-core/overmind", Repository = "https://github.com/overmind-core/overmind" }
-version = "0.1.55"
+version = "0.1.56"
 
 
     [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -1544,7 +1544,7 @@ wheels = [
 
 [[package]]
 name = "overmind"
-version = "0.1.55"
+version = "0.1.56"
 source = { editable = "." }
 dependencies = [
     { name = "litellm" },


### PR DESCRIPTION
in case of a custom model, we don’t want tracing to break just because its cost can’t be calculated