### PR TITLE
Convert content to British English; rename optimize command to optimise

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,6 @@ OPENAI_API_KEY=
 ANTHROPIC_API_KEY=
 GEMINI_API_KEY=
 
-# Used as the optimizer’s analyzer model (and as the default in the model picker).
+# Used as the optimiser’s analyser model (and as the default in the model picker).
 ANALYZER_MODEL=claude-sonnet-4-6
 SYNTHETIC_DATAGEN_MODEL=claude-opus-4-6

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Overmind is two things in one package:
 
 - **Tracing SDK** — drop-in observability for LLM agents. Decorate your code, get structured traces of every LLM call and tool invocation.
-- **Optimizer client** — a thin, agent- and codebase-agnostic executioner. The optimization loop (experiments → iterations → candidates → commands) is configured and driven **server-side** by the [Overmind Console](https://console.overmindlab.ai/). This repo just registers your machine, leases queued commands, runs them against your repo, and reports results back.
+- **Optimiser client** — a thin, agent- and codebase-agnostic executioner. The optimisation loop (experiments → iterations → candidates → commands) is configured and driven **server-side** by the [Overmind Console](https://console.overmindlab.ai/). This repo just registers your machine, leases queued commands, runs them against your repo, and reports results back.
 
 **Documentation:** [Overmind guide](https://docs.overmindlab.ai/guides/overmind_optimizer/)
 
@@ -39,13 +39,13 @@ def search(query: str) -> list[dict]:
 
 Available decorators/helpers: `entry_point`, `workflow`, `tool`, `function`, plus `start_span` (context manager), `set_tag`, `set_user`, and `capture_exception` for Sentry-style annotations on the current span.
 
-## Optimize
+## Optimise
 
-Set up and configure the experiment (agent, policy, dataset, iterations) in the [Console](https://console.overmindlab.ai/). Then, from the root of the repo you want optimized:
+Set up and configure the experiment (agent, policy, dataset, iterations) in the [Console](https://console.overmindlab.ai/). Then, from the root of the repo you want optimised:
 
 ```bash
 export OVERMIND_API_KEY=<your-api-key>
-overmind optimize
+overmind optimise
 ```
 
 This registers the current machine with the backend and loops forever: it leases queued commands from the experiment you configured in the Console, checks out the iteration's git branch (applying its candidate diff as a commit), runs the shell command against your repo, and reports the result back. Stop it any time with Ctrl-C; re-running is safe and idempotent per iteration branch.
@@ -78,12 +78,12 @@ overmind skills sync <skill-name>
 | `Overmind Register Agent`     | Create or register an Overmind agent entrypoint and bootstrap provider config.     |
 | `Overmind Generate Agent`     | Build an agent from scratch using natural language.                               |
 | `Overmind Telemetry`          | Configure Overmind tracing for your AI project.                                   |
-| `Ponytail`                    | Review an optimization report and adjust the policy, eval spec, or dataset.       |
+| `Ponytail`                    | Review an optimisation report and adjust the policy, eval spec, or dataset.       |
 
 ## CLI reference
 
 ```text
-overmind optimize [OPTIONS]         Register this machine and run the optimization loop
+overmind optimise [OPTIONS]         Register this machine and run the optimisation loop
 overmind skills list [--verbose]    List installed/available skills
 overmind skills sync <name>...      Sync one or more skills to the latest version
 ```

--- a/docs/tracing-attributes.md
+++ b/docs/tracing-attributes.md
@@ -11,7 +11,7 @@ Rules of the road:
   inline a raw string.
 - Token usage and cost use the **`genai.*`** keys (NOT the OTel semconv
   `gen_ai.*`). The SDK *also* emits the `gen_ai.*` semconv keys alongside them so
-  OTel-native consumers and the optimizer's `trace_reader` keep working, and the
+  OTel-native consumers and the optimiser's `trace_reader` keep working, and the
   on-end enrichment processor mirrors any `gen_ai.*` usage produced by
   third-party auto-instrumentors into these canonical keys.
 - **Never zero-fill.** A token count / cost we don't have is omitted, so the

--- a/examples/support_triage/README.md
+++ b/examples/support_triage/README.md
@@ -20,7 +20,7 @@ drafts a first reply. Uses an internal KB, a customer lookup, and public docs.
 overmind agent register support-triage agent:run
 overmind agent validate support-triage --data data/seed.json
 overmind setup support-triage
-overmind optimize support-triage
+overmind optimise support-triage
 ```
 
 ## Trace it

--- a/overmind/__init__.py
+++ b/overmind/__init__.py
@@ -1,7 +1,7 @@
 """
 Overmind Python Client
 
-Overmind: autonomous agent optimization through structured experimentation.
+Overmind: autonomous agent optimisation through structured experimentation.
 Overmind: automatic observability for LLM applications.
 
 """

--- a/overmind/__main__.py
+++ b/overmind/__main__.py
@@ -1,7 +1,7 @@
-"""Overmind CLI — optimize LLM agents and manage agent skills.
+"""Overmind CLI — optimise LLM agents and manage agent skills.
 
 Commands:
-    optimize                  Run the optimization loop on a registered agent.
+    optimise                  Run the optimisation loop on a registered agent.
     skills                    Manage Overmind agent skills.
 
 Use --help with any command or subcommand for details.
@@ -27,8 +27,8 @@ from overmind.skills import skills_app
 
 app = typer.Typer(
     name="overmind",
-    help="Overmind CLI optimize LLM agents and manage agent skills.",
-    epilog="Overmind https://overmindlab.ai is a tool for optimizing LLM agents and managing agent skills.",
+    help="Overmind CLI optimise LLM agents and manage agent skills.",
+    epilog="Overmind https://overmindlab.ai is a tool for optimising LLM agents and managing agent skills.",
     pretty_exceptions_enable=True,
     no_args_is_help=True,
 )
@@ -38,8 +38,10 @@ console = Console()
 current_dir = os.path.dirname(os.path.abspath(__file__))
 
 
-@app.command(help="Register this machine as an optimizer and run the optimization loop.")
-def optimize(
+OPTIMISE_HELP = "Register this machine as an optimiser and run the optimisation loop."
+
+
+def optimise(
     api_key: Annotated[
         str,
         typer.Option(envvar="OVERMIND_API_KEY", help="Overmind API key", show_default=False),
@@ -59,7 +61,7 @@ def optimize(
     log_level: Annotated[str, typer.Option(envvar="OPTIMIZER_LOG_LEVEL", help="DEBUG/INFO/WARNING/ERROR")] = "INFO",
 ):
     """
-    Register with the Overmind backend and run the optimization loop: poll for
+    Register with the Overmind backend and run the optimisation loop: poll for
     queued commands (from the server-side experiment FSM), run them against
     the repo in ``cwd``, and report results back.
     """
@@ -72,6 +74,11 @@ def optimize(
         heartbeat_interval=heartbeat_interval,
     )
 
+
+app.command("optimise", help=OPTIMISE_HELP)(optimise)
+# ``optimize`` stays registered (hidden) so scripts written against the old
+# American spelling keep working.
+app.command("optimize", hidden=True, help=f"Deprecated alias for `optimise`. {OPTIMISE_HELP}")(optimise)
 
 app.add_typer(skills_app, name="skills")
 

--- a/overmind/attrs.py
+++ b/overmind/attrs.py
@@ -134,7 +134,7 @@ SETUP_SCOPE = "overmind.setup.scope"
 SETUP_OPTIMIZABLE_ELEMENTS = "overmind.setup.optimizable_elements"
 
 # ---------------------------------------------------------------------------
-# `overmind optimize` (overmind/commands/optimize_cmd.py)
+# `overmind optimise` (overmind/commands/optimize_cmd.py)
 # ---------------------------------------------------------------------------
 OPTIMIZE_AGENT_NAME = "overmind.optimize.agent_name"
 OPTIMIZE_AGENT_PATH = "overmind.optimize.agent_path"
@@ -159,11 +159,11 @@ OPTIMIZE_MODEL_BACKTESTING = "overmind.optimize.model_backtesting"
 OPTIMIZE_BACKTEST_MODELS = "overmind.optimize.backtest_models"
 OPTIMIZE_EVAL_SPEC_PATH = "overmind.optimize.eval_spec_path"
 OPTIMIZE_DATA_PATH = "overmind.optimize.data_path"
-# Full eval_spec.json (JSON string) for OTLP ingest to refresh Agent eval fields during optimize.
+# Full eval_spec.json (JSON string) for OTLP ingest to refresh Agent eval fields during optimise.
 OPTIMIZE_EVAL_SPEC = "overmind.optimize.eval_spec"
 
-# Optimizer pipeline (overmind/optimize/optimizer.py) — runtime tags emitted
-# from the optimizer's spans during a run.
+# Optimiser pipeline (overmind/optimize/optimizer.py) — runtime tags emitted
+# from the optimiser's spans during a run.
 OPTIMIZE_PHASE = "overmind.optimize.phase"
 OPTIMIZE_DATASET_TOTAL = "overmind.optimize.dataset_total"
 OPTIMIZE_DATASET_TRAIN = "overmind.optimize.dataset_train"
@@ -189,7 +189,7 @@ OPTIMIZE_ITERATION_REASON = "overmind.optimize.iteration_reason"
 # stamps its phase here so OTLP can attribute every span back to its
 # step (init / baseline / diagnose / evaluate / accept / report).
 OPTIMIZE_STEP = "overmind.optimize.step"
-# Terminal state of the optimize run.  ``running`` while in flight,
+# Terminal state of the optimise run.  ``running`` while in flight,
 # flipped to ``completed`` / ``failed`` / ``cancelled`` by the step
 # that owns end-of-run.  OTLP uses this (alongside the legacy
 # ``is_optimize_root`` heuristic) to drive ``Job.status``.
@@ -209,7 +209,7 @@ OPTIMIZE_ITERATION_SUGGESTIONS = "overmind.optimize.iteration_suggestions"
 OPTIMIZE_ACCEPTED = "overmind.optimize.accepted"
 OPTIMIZE_FINAL_BEST_SCORE = "overmind.optimize.final_best_score"
 # Final report.md text produced by ``Optimizer._generate_report``.
-# Stamped on the optimize run span so OTLP can persist it on the
+# Stamped on the optimise run span so OTLP can persist it on the
 # corresponding ``Job.report_markdown`` row.
 OPTIMIZE_REPORT_MARKDOWN = "overmind.optimize.report_markdown"
 # Final best agent code text (``Job.best_agent_code``).
@@ -291,7 +291,7 @@ RUN_CASE_CONFIDENCE = "overmind.run.case.confidence"
 # ``optimizer.evaluate_worktree`` — invoked from the skill-driven
 # `overmind optimize-step evaluate` flow, scores a worktree's candidate
 # agent against the training set.  These tags let the UI surface
-# per-candidate / per-iteration scores even when the optimizer is being
+# per-candidate / per-iteration scores even when the optimiser is being
 # driven from a host coding agent rather than the legacy loop.
 OPTIMIZE_WORKTREE_RUN_NAME = "overmind.optimize.worktree.run_name"
 OPTIMIZE_WORKTREE_ENTRY_PATH = "overmind.optimize.worktree.entry_path"
@@ -302,7 +302,7 @@ OPTIMIZE_WORKTREE_PASS_RATE = "overmind.optimize.worktree.pass_rate"
 OPTIMIZE_WORKTREE_DURATION_SECONDS = "overmind.optimize.worktree.duration_seconds"
 
 # ---------------------------------------------------------------------------
-# Cross-run optimization state (overmind/optimize/run_state.py)
+# Cross-run optimisation state (overmind/optimize/run_state.py)
 # ---------------------------------------------------------------------------
 RUN_STATE_TOTAL_RUNS = "overmind.run_state.total_runs"
 RUN_STATE_REGRESSION_CASES = "overmind.run_state.regression_cases"
@@ -382,7 +382,7 @@ CODING_AGENT_EXIT_REASON = "overmind.coding_agent.exit_reason"
 # (NOT the OTel semconv ``input_tokens`` / ``output_tokens``).
 #
 # The SDK ALSO emits the OTel semconv ``gen_ai.*`` keys below (see
-# ``OTEL_*``) so third-party consumers and the optimizer's ``trace_reader``
+# ``OTEL_*``) so third-party consumers and the optimiser's ``trace_reader``
 # keep working, and the on-end enrichment processor mirrors any ``gen_ai.*``
 # usage produced by auto-instrumentors into these canonical keys.
 # ---------------------------------------------------------------------------
@@ -423,7 +423,7 @@ LLM_USAGE_TOTAL_TOKENS = "genai.usage.total_tokens"
 # OpenTelemetry GenAI semantic-convention keys.
 #
 # Emitted ALONGSIDE the canonical ``genai.*`` keys above so OTel-native
-# consumers and the optimizer's ``trace_reader`` (which parses local JSONL
+# consumers and the optimiser's ``trace_reader`` (which parses local JSONL
 # traces) keep resolving model + tokens.  Never read these on the server —
 # read the canonical ``genai.*`` keys instead.
 # ---------------------------------------------------------------------------

--- a/overmind/optimizer.py
+++ b/overmind/optimizer.py
@@ -1,18 +1,18 @@
 #!/usr/bin/env python3
-"""Overmind optimizer client a tiny, agent and codebase-agnostic command runner.
+"""Overmind optimiser client a tiny, agent and codebase-agnostic command runner.
 
-The optimizer FSM (experiment -> iterations -> candidates -> commands) now lives
+The optimiser FSM (experiment -> iterations -> candidates -> commands) now lives
 server-side. This file is the *client*: it registers with the
-backend, polls for queued optimizer commands, runs whatever shell the server
-hands it (from the repo root — you launch the optimizer there — optionally
+backend, polls for queued optimiser commands, runs whatever shell the server
+hands it (from the repo root — you launch the optimiser there — optionally
 applying a candidate git diff first), and reports the result back. The server's
 clone path is server-side only and is never used here, so the same binary
-optimizes any repo.
+optimises any repo.
 
 Usage:
     pip install "overmind>=0.1.54" && OVERMIND_API_KEY=<api-key> \\
     OVERMIND_API_URL=http://localhost:8000 \\
-    overmind optimize
+    overmind optimise
 
 Logging: INFO by default (startup, registration, every command + its outcome,
 periodic idle heartbeat). Set ``OPTIMIZER_LOG_LEVEL=DEBUG`` to see the full
@@ -56,7 +56,7 @@ import requests
 API_URL = os.getenv("OVERMIND_API_URL", "https://api.overmindlab.ai").rstrip("/")
 API_KEY = os.getenv("OVERMIND_API_KEY", "")
 # Local working dir for git + command runs. We ALWAYS run from the repo root: the
-# optimizer is launched there, so this defaults to the current directory. The
+# optimiser is launched there, so this defaults to the current directory. The
 # server-provided path (``cmd["cwd"]`` = its own clone_path) is server-side only
 # and must never be used to locate the repo on the client.
 WORK_DIR = os.getenv("OVERMIND_CWD", "") or None
@@ -477,7 +477,7 @@ def run_optimizer(
     base_ref = _current_branch(cwd) or "main"
 
     logger.info(
-        "optimizer starting: api=%s host=%s idle=%.1fs heartbeat=%.0fs base_ref=%s",
+        "optimiser starting: api=%s host=%s idle=%.1fs heartbeat=%.0fs base_ref=%s",
         api_url,
         socket.gethostname(),
         idle_interval,

--- a/overmind/skills.py
+++ b/overmind/skills.py
@@ -1,7 +1,7 @@
-"""Overmind CLI — optimize LLM agents and manage agent skills.
+"""Overmind CLI — optimise LLM agents and manage agent skills.
 
 Commands:
-    optimize                  Run the optimization loop on a registered agent.
+    optimise                  Run the optimisation loop on a registered agent.
     skills                    Manage Overmind agent skills.
 
 Use --help with any command or subcommand for details.

--- a/overmind/skills/overmind-agent-telemetry/SKILL.md
+++ b/overmind/skills/overmind-agent-telemetry/SKILL.md
@@ -15,7 +15,7 @@ or ride alongside a telemetry stack the project already has.
 ```
 - [ ] 1. Detect existing telemetry (OpenTelemetry, Traceloop, LangSmith, etc.)
 - [ ] 2. Install the SDK and set env vars
-- [ ] 3. Initialize — greenfield OR fan-out onto the existing provider
+- [ ] 3. Initialise — greenfield OR fan-out onto the existing provider
 - [ ] 4. Auto-instrument the LLM providers in use
 - [ ] 5. Add custom spans where useful
 - [ ] 6. Flush on shutdown and verify traces land in the Console
@@ -33,7 +33,7 @@ rg -n "set_tracer_provider|TracerProvider|opentelemetry|traceloop|Traceloop|lang
   installs the provider.
 - **A `TracerProvider` is already set** (OTel directly, Traceloop/OpenLLMetry,
   LangSmith's OTel bridge, etc.) → fan-out path (Step 3b). OpenTelemetry only
-  honors the **first** `set_tracer_provider()` call and ignores later ones with
+  honours the **first** `set_tracer_provider()` call and ignores later ones with
   a warning, so calling `overmind.init()` on top of an existing provider would
   silently attach nothing. Instead, add Overmind's exporter to the provider the
   project already owns.

--- a/overmind/tracing.py
+++ b/overmind/tracing.py
@@ -269,7 +269,7 @@ class _GenAiUsageSpanProcessor(SpanProcessor):
 
 
 def _attach_remote_parent_if_present() -> None:
-    """Attach the W3C ``TRACEPARENT`` env var (injected by the optimizer into
+    """Attach the W3C ``TRACEPARENT`` env var (injected by the optimiser into
     agent subprocesses) as the ambient parent context. No-op when absent."""
     raw = os.environ.get("TRACEPARENT") or os.environ.get("OTEL_TRACEPARENT")
     if not raw:
@@ -287,7 +287,7 @@ def _attach_remote_parent_if_present() -> None:
 
 
 # ---------------------------------------------------------------------------
-# SDK initialization
+# SDK initialisation
 # ---------------------------------------------------------------------------
 
 
@@ -317,7 +317,7 @@ def init(
     agent_name: str | None = None,
     project_id: str | None = None,
 ):
-    """Initialize the Overmind SDK for automatic monitoring.
+    """Initialise the Overmind SDK for automatic monitoring.
 
     Args:
         overmind_api_key: API key; defaults to OVERMIND_API_KEY env var.
@@ -337,12 +337,12 @@ def init(
 
     if _initialized:
         # Re-init only refreshes identity + providers; exporters stay as-is.
-        logger.debug(f"Overmind SDK already initialized, reinitializing with providers: {providers}")
+        logger.debug(f"Overmind SDK already initialised, reinitialising with providers: {providers}")
         _seed_identity_context(agent_id, agent_name, project_id)
         enable_tracing(providers)
         return
 
-    # Optimize-step subprocess: the runner wrapper set up a file-exporter
+    # Optimise-step subprocess: the runner wrapper set up a file-exporter
     # provider (OVERMIND_TRACE_FILE) and stripped the API key — reuse it
     # instead of crashing or replacing the exporter.
     if os.environ.get("OVERMIND_TRACE_FILE") and not (overmind_api_key or os.environ.get("OVERMIND_API_KEY")):
@@ -351,7 +351,7 @@ def init(
         logger.debug(
             "Overmind SDK init() skipped: OVERMIND_TRACE_FILE is set and no "
             "OVERMIND_API_KEY available; reusing the local file-exporter "
-            "TracerProvider configured by the optimize runner wrapper.",
+            "TracerProvider configured by the optimise runner wrapper.",
         )
         _tracer = trace.get_tracer("overmind", sdk_version)
         _seed_identity_context(agent_id, agent_name, project_id)
@@ -412,13 +412,13 @@ def init(
     _attach_remote_parent_if_present()
 
     _initialized = True
-    logger.info(f"Overmind SDK initialized: service={service_name}, environment={environment}")
+    logger.info(f"Overmind SDK initialised: service={service_name}, environment={environment}")
 
 
 def get_tracer() -> trace.Tracer:
-    """Return the Overmind tracer; raises RuntimeError if not initialized."""
+    """Return the Overmind tracer; raises RuntimeError if not initialised."""
     if not _initialized or _tracer is None:
-        raise RuntimeError("Overmind SDK not initialized. Call overmind.init() first.")
+        raise RuntimeError("Overmind SDK not initialised. Call overmind.init() first.")
     return _tracer
 
 
@@ -869,7 +869,7 @@ def set_iteration_analytics(
     reason: str | None = None,
     dimension_scores: Mapping[str, float] | None = None,
 ) -> None:
-    """Stamp optimizer iteration analytics (``overmind.optimize.*``) on the
+    """Stamp optimiser iteration analytics (``overmind.optimize.*``) on the
     current span."""
     set_tag(attrs.OPTIMIZE_ITERATION, iteration)
     set_tag(attrs.OPTIMIZE_ITERATION_DECISION, decision)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ name = "overmind"
 readme = "README.md"
 requires-python = ">=3.10,<4" # todo; remove the upper bound
 urls = { Homepage = "https://github.com/overmind-core/overmind", Repository = "https://github.com/overmind-core/overmind" }
-version = "0.1.56"
+version = "0.1.57"
 
 
     [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "opentelemetry-overmind>=0.53.0",
     "litellm>=1.90.2",
 ]
-description = "Overmind — autonomous agent optimization through structured experimentation"
+description = "Overmind — autonomous agent optimisation through structured experimentation"
 keywords = ["overmind", "ai", "api", "client", "policy", "enforcement"]
 name = "overmind"
 readme = "README.md"

--- a/tests/test_attrs.py
+++ b/tests/test_attrs.py
@@ -6,7 +6,7 @@ silently break trace ingestion.
 The CANONICAL token/cost namespace the Overmind server rolls up is ``genai.*``
 (see ``overbae/api/overmind_attrs.py`` + ``otlp.py::_build_span_usage``).  The
 SDK emits those keys AND, alongside them, the OTel GenAI semconv ``gen_ai.*``
-keys (defined here as ``OTEL_*``) so OTel-native consumers and the optimizer's
+keys (defined here as ``OTEL_*``) so OTel-native consumers and the optimiser's
 :mod:`overmind.optimize.trace_reader` keep resolving model + tokens.
 """
 

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1,4 +1,4 @@
-"""No-network sanity checks for the optimizer client's command-running path.
+"""No-network sanity checks for the optimiser client's command-running path.
 
 Moved from the old ``selftest()`` in :mod:`overmind.optimizer` — asserts the
 traceparent shape and that a trivial command round-trips into the result dict

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -114,10 +114,10 @@ def test_sdk_init_handles_missing_deps():
 
 
 def test_get_tracer_before_init():
-    """Test that get_tracer raises if SDK not initialized."""
+    """Test that get_tracer raises if SDK not initialised."""
     from overmind import tracing
 
-    with pytest.raises(RuntimeError, match="not initialized"):
+    with pytest.raises(RuntimeError, match="not initialised"):
         tracing.get_tracer()
 
 


### PR DESCRIPTION
## What changed

**British English sweep** (prose only — user-facing CLI output, docstrings, help text, comments, README and docs):

- `overmind/__main__.py`, `overmind/skills.py` — module docstrings, Typer app help + epilog
- `overmind/optimizer.py` — module docstring, comments, `optimiser starting:` log line
- `overmind/tracing.py` — `Initialise the Overmind SDK…` docstring, `Overmind SDK initialised:` / `already initialised, reinitialising` log lines, `Overmind SDK not initialised.` RuntimeError message, section comment
- `overmind/attrs.py` — comments only (`Optimiser pipeline`, `Cross-run optimisation state`, `the optimiser's trace_reader`, …)
- `overmind/__init__.py`, `pyproject.toml` `description` — "optimisation"
- `README.md`, `docs/tracing-attributes.md`, `examples/support_triage/README.md`, `overmind-agent-telemetry/SKILL.md` (`Initialise`, `honours`)
- `.env.example` comment — "optimiser's analyser model" (the `ANALYZER_MODEL` var name is unchanged)
- `tests/` — docstrings, plus the `not initialised` match string that pairs with the reworded error

Much of the repo was already British (`normalised`, `serialised`, `behaviour`, `prioritises`, `recognises`, `grey`).

## Command rename

`overmind optimize` → **`overmind optimise`**.

`optimize` stays registered as a **hidden, deprecated alias** bound to the same callback, so existing user scripts and the platform's copy-paste command keep working:

```python
app.command("optimise", help=OPTIMISE_HELP)(optimise)
app.command("optimize", hidden=True, help=f"Deprecated alias for `optimise`. {OPTIMISE_HELP}")(optimise)
```

The alias is omitted from `--help` output but its own `--help` labels it "Deprecated alias for `optimise`".

There is **no `optimize-step` subcommand in this repo** — it only appears in two `attrs.py` comments describing the private optimiser repo's flow, and those were left as `optimize-step` rather than renaming a command this repo does not own.

## Wire-contract values deliberately left alone

- OTel attribute keys and the `overmind.optimize.*` prefix — every `OPTIMIZE_* = "overmind.optimize.…"` value is byte-identical to `main`
- `SETUP_OPTIMIZABLE_ELEMENTS = "overmind.setup.optimizable_elements"`
- `COMMAND = "overmind.command"` — defined but never assigned in this repo, so there was nothing to pin to `"optimize"`
- Span-name references in comments: `optimizer.iteration`, `optimizer.evaluate_worktree`, `optimizer.run_agent_on_dataset`, `optimizer.run_case_with_plan`, `optimizer.build_eval_results`
- Env vars: `OPTIMIZER_POLL_INTERVAL`, `OPTIMIZER_HEARTBEAT_INTERVAL`, `OPTIMIZER_LOG_LEVEL`, `ANALYZER_MODEL`
- Python identifiers and module names: `overmind/optimizer.py`, `OptimizerAPI`, `run_optimizer`, `_normalize_for_json`, `_MAX_NORMALIZE_DEPTH`, `_finalize_span`, `_initialized`, and the public `serialize` / `serialize_dataclass` exports
- `logging.getLogger("optimizer.client")`, `"cli_version": "optimizer/0.1"`, thread name `optimizer-heartbeat`
- Module-path references in comments (`overmind/optimize/analyzer.py`, `optimize_cmd.py`, `is_optimize_root`, `Optimizer._generate_report`)
- `"License :: OSI Approved :: MIT License"` and `"Programming Language :: Python :: 3"` trove classifiers
- `"Unauthorized"` in a mocked backend error body; `microfiber` in a product-description test fixture
- Typer's own built-in `customize the installation` completion help

## Checks

`make lint-check` — All checks passed, 9 files already formatted.
`make test` — 166 passed.
`python -m overmind --help`, `optimise --help`, `optimize --help` all verified by hand.

## Note

The repo's `pre-commit` config is not green on `main` either (3 pre-existing ruff errors in `tests/`, and its `mdformat` hook mangles `SKILL.md`'s YAML frontmatter into a heading and reflows unrelated tables). Its output was deliberately not committed here.
