### PR TITLE
feat(optimizer): per-command env, secret redaction, base-ref smoke fix

### DIFF
--- a/overmind/__init__.py
+++ b/overmind/__init__.py
@@ -6,7 +6,7 @@ Overmind: automatic observability for LLM applications.
 
 """
 
-__version__ = "0.1.54"
+__version__ = "0.1.58"
 
 from opentelemetry.overmind.prompt import PromptString
 

--- a/overmind/optimizer.py
+++ b/overmind/optimizer.py
@@ -53,6 +53,8 @@ from itertools import groupby
 import psutil
 import requests
 
+from . import __version__
+
 API_URL = os.getenv("OVERMIND_API_URL", "https://api.overmindlab.ai").rstrip("/")
 API_KEY = os.getenv("OVERMIND_API_KEY", "")
 # Local working dir for git + command runs. We ALWAYS run from the repo root: the
@@ -67,6 +69,7 @@ BUSY_INTERVAL = 0.5  # poll fast while there is work to drain
 MAX_BACKOFF = 30.0  # cap the exponential backoff on transport errors
 OUTPUT_TAIL = 8000  # chars of stdout/stderr to report back
 LOG_SNIPPET = 200  # chars of an error surfaced at INFO (full body rides DEBUG)
+REDACTED_SECRET = "[REDACTED]"
 
 logger = logging.getLogger("optimizer.client")
 
@@ -116,7 +119,7 @@ class OptimizerAPI:
         runtime = _runtime_metadata()
         payload = {
             "hostname": socket.gethostname(),
-            "cli_version": "optimizer/0.1",
+            "cli_version": f"optimizer/{__version__}",
             "metadata": {
                 "pid": os.getpid(),
                 "cpu.count": os.cpu_count(),  # traditional API, usually logical
@@ -228,6 +231,28 @@ def _new_traceparent() -> tuple[str, str]:
     return f"00-{trace_id}-{span_id}-01", trace_id
 
 
+def _secret_env_values(command_env: dict, effective_env: dict[str, str]) -> tuple[str, ...]:
+    """Return non-empty values from secret-looking command environment keys."""
+    secret_markers = ("KEY", "TOKEN", "SECRET", "PASSWORD")
+    values = {
+        str(value)
+        for name, value in command_env.items()
+        if value is not None and str(value) and any(marker in str(name).upper() for marker in secret_markers)
+    }
+    # Local-source OpenRouter runs omit the key from command_env by design, but
+    # command output must still never send the inherited local key upstream.
+    if local_openrouter_key := effective_env.get("OPENROUTER_API_KEY"):
+        values.add(local_openrouter_key)
+    return tuple(sorted(values, key=len, reverse=True))
+
+
+def _redact_secret_values(text: str, secret_values: tuple[str, ...]) -> str:
+    """Replace injected secret values before command output is stored or logged."""
+    for value in secret_values:
+        text = text.replace(value, REDACTED_SECRET)
+    return text
+
+
 def _git_apply(diff_text: str, cwd: str | None, *, reverse: bool = False) -> subprocess.CompletedProcess:
     args = ["git", "apply", "--whitespace=nowarn"]
     if reverse:
@@ -246,6 +271,26 @@ def _current_branch(cwd: str | None) -> str:
         text=True,
     )
     return proc.stdout.strip()
+
+
+def _optimizer_base_ref(cwd: str | None) -> str:
+    """Return the clean commit beneath any optimizer-created candidate commits."""
+    proc = subprocess.run(["git", "rev-parse", "HEAD"], cwd=cwd, capture_output=True, text=True)
+    ref = proc.stdout.strip()
+    while ref:
+        subject = subprocess.run(
+            ["git", "show", "-s", "--format=%s", ref],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        if not subject.startswith("apply patch for candidate "):
+            return ref
+        parent = subprocess.run(["git", "rev-parse", f"{ref}^"], cwd=cwd, capture_output=True, text=True)
+        if parent.returncode != 0:
+            break
+        ref = parent.stdout.strip()
+    return _current_branch(cwd) or "main"
 
 
 def _setup_candidate_branch(base_ref: str, candidate_id: str, patch: str, cwd: str | None) -> None:
@@ -290,7 +335,14 @@ def run_command(cmd: dict, cwd: str | None = None) -> tuple[bool, dict, str]:
     candidate_id = cmd.get("candidate_id", "")
     timeout = int(cmd.get("timeout") or 600)
     traceparent, trace_id = _new_traceparent()
-    env = {**os.environ, "TRACEPARENT": traceparent}
+    # The server supplies the matrix model and, for platform-BYOK runs, the
+    # server-provided project key.  Per-command values override the process only
+    # when explicitly present: local-source runs omit the key and therefore
+    # keep the executioner's local OPENROUTER_API_KEY untouched.
+    command_env = cmd.get("environment") if isinstance(cmd.get("environment"), dict) else {}
+    env = {**os.environ, **{str(k): str(v) for k, v in command_env.items() if v is not None}}
+    env["TRACEPARENT"] = traceparent
+    secret_values = _secret_env_values(command_env, env)
 
     if not command:
         logger.error("command %s has empty command text; reporting failure", cmd_id)
@@ -318,20 +370,22 @@ def run_command(cmd: dict, cwd: str | None = None) -> tuple[bool, dict, str]:
         timeout,
         traceparent,
     )
-    logger.debug("command %s shell:\n%s", cmd_id, command)
+    logger.debug("command %s shell:\n%s", cmd_id, _redact_secret_values(command, secret_values))
 
     started = time.monotonic()
     try:
         proc = subprocess.run(command, shell=True, cwd=cwd, env=env, capture_output=True, text=True, timeout=timeout)
         elapsed = time.monotonic() - started
         success = proc.returncode == 0
+        stdout = _redact_secret_values(proc.stdout or "", secret_values)
+        stderr = _redact_secret_values(proc.stderr or "", secret_values)
         result = {
-            "output": (proc.stdout or "")[-OUTPUT_TAIL:],
-            "stdout": (proc.stdout or "")[-OUTPUT_TAIL:],
+            "output": stdout[-OUTPUT_TAIL:],
+            "stdout": stdout[-OUTPUT_TAIL:],
             "exit_code": proc.returncode,
             "trace_id": trace_id,
         }
-        error = "" if success else (proc.stderr or "")[-OUTPUT_TAIL:]
+        error = "" if success else stderr[-OUTPUT_TAIL:]
         if success:
             logger.info("command %s ok in %.1fs (exit=0)", cmd_id, elapsed)
         else:
@@ -374,7 +428,23 @@ def poll_once(api: OptimizerAPI, session_id: str, cwd: str | None = None, base_r
         batch = list(batch_iter)
         patch = batch[0].get("candidate_patch", "")
 
-        if candidate_id and base_ref:
+        if not candidate_id and base_ref:
+            try:
+                # Smoke runs the unchanged harness. A non-forced checkout keeps
+                # local tracked edits safe by failing instead of discarding them.
+                subprocess.run(
+                    ["git", "checkout", base_ref],
+                    cwd=cwd,
+                    check=True,
+                    capture_output=True,
+                )
+            except Exception as exc:
+                logger.error("base checkout failed: %s", exc)
+                for cmd in batch:
+                    api.submit_result(cmd["id"], success=False, result={}, error=f"base checkout failed: {exc}")
+                total += len(batch)
+                continue
+        elif candidate_id and base_ref:
             try:
                 _setup_candidate_branch(base_ref, candidate_id, patch, cwd)
             except Exception as exc:
@@ -474,7 +544,7 @@ def run_optimizer(
 
     # Capture the base branch before any candidate checkouts so every candidate
     # can branch from the same clean starting point.
-    base_ref = _current_branch(cwd) or "main"
+    base_ref = _optimizer_base_ref(cwd)
 
     logger.info(
         "optimiser starting: api=%s host=%s idle=%.1fs heartbeat=%.0fs base_ref=%s",

--- a/overmind/optimizer.py
+++ b/overmind/optimizer.py
@@ -335,10 +335,11 @@ def run_command(cmd: dict, cwd: str | None = None) -> tuple[bool, dict, str]:
     candidate_id = cmd.get("candidate_id", "")
     timeout = int(cmd.get("timeout") or 600)
     traceparent, trace_id = _new_traceparent()
-    # The server supplies the matrix model and, for platform-BYOK runs, the
-    # server-provided project key.  Per-command values override the process only
-    # when explicitly present: local-source runs omit the key and therefore
-    # keep the executioner's local OPENROUTER_API_KEY untouched.
+    # The server supplies the matrix model per command (OPENROUTER_MODEL) and
+    # never sends keys. Platform (Overmind credits) runs authenticate with the
+    # daemon's own OVERMIND_API_KEY/OVERMIND_API_URL; local-source runs keep the
+    # user's local OPENROUTER_API_KEY. Per-command values override the process
+    # only when explicitly present — a missing key keeps the local value.
     command_env = cmd.get("environment") if isinstance(cmd.get("environment"), dict) else {}
     env = {**os.environ, **{str(k): str(v) for k, v in command_env.items() if v is not None}}
     env["TRACEPARENT"] = traceparent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ name = "overmind"
 readme = "README.md"
 requires-python = ">=3.10,<4" # todo; remove the upper bound
 urls = { Homepage = "https://github.com/overmind-core/overmind", Repository = "https://github.com/overmind-core/overmind" }
-version = "0.1.57"
+version = "0.1.58"
 
 
     [project.scripts]

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -57,35 +57,34 @@ def test_run_command_failure_reports_exit_code_and_stderr():
     assert not ok and result["exit_code"] == 3 and "boom" in error, (ok, result, error)
 
 
-def test_run_command_platform_env_overrides_stale_local_key(monkeypatch):
+def test_run_command_server_model_wins_and_local_key_redacted(monkeypatch):
+    # The server sends only OPENROUTER_MODEL per command (never a key), and an
+    # explicit command_env value wins over the daemon's own env. The inherited
+    # local key must never appear in captured output.
+    monkeypatch.setenv("OPENROUTER_MODEL", "local-model")
     monkeypatch.setenv("OPENROUTER_API_KEY", "local-secret")
     ok, result, error = run_command({
         "command": 'printf \'%s|%s\' "$OPENROUTER_MODEL" "$OPENROUTER_API_KEY"',
         "timeout": 10,
-        "environment": {
-            "OPENROUTER_MODEL": "openai/gpt-5",
-            "OPENROUTER_API_KEY": "server-secret",
-        },
+        "environment": {"OPENROUTER_MODEL": "openai/gpt-5"},
     })
     assert ok, (result, error)
     assert result["output"] == "openai/gpt-5|[REDACTED]"
-    assert "server-secret" not in result["output"]
+    assert "local-secret" not in result["output"]
 
 
-def test_run_command_redacts_injected_secret_from_stderr_and_debug_logs(caplog):
+def test_run_command_redacts_local_key_from_stderr_and_debug_logs(caplog, monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "local-secret")
     with caplog.at_level(logging.DEBUG, logger="optimizer.client"):
         ok, result, error = run_command({
             "command": 'printf \'model=%s key=%s\\n\' "$OPENROUTER_MODEL" "$OPENROUTER_API_KEY" >&2; exit 1',
             "timeout": 10,
-            "environment": {
-                "OPENROUTER_MODEL": "openai/gpt-5",
-                "OPENROUTER_API_KEY": "server-secret",
-            },
+            "environment": {"OPENROUTER_MODEL": "openai/gpt-5"},
         })
     assert not ok
     assert result["output"] == ""
     assert error == "model=openai/gpt-5 key=[REDACTED]\n"
-    assert "server-secret" not in caplog.text
+    assert "local-secret" not in caplog.text
     assert "openai/gpt-5" in caplog.text
 
 
@@ -101,21 +100,6 @@ def test_run_command_local_env_keeps_local_key(monkeypatch):
     assert "local-secret" not in result["output"]
 
 
-def test_run_command_explicit_empty_key_overrides_local_key(monkeypatch):
-    monkeypatch.setenv("OPENROUTER_API_KEY", "local-secret")
-    ok, result, error = run_command({
-        "command": 'printf \'%s|%s\' "$OPENROUTER_MODEL" "$OPENROUTER_API_KEY"',
-        "timeout": 10,
-        "environment": {
-            "OPENROUTER_MODEL": "openai/gpt-5",
-            "OPENROUTER_API_KEY": "",
-        },
-    })
-    assert ok, (result, error)
-    assert result["output"] == "openai/gpt-5|"
-    assert "local-secret" not in result["output"]
-
-
 # ── OptimizerAPI.poll sends lease flag ───────────────────────────────────────
 
 
@@ -126,8 +110,7 @@ def _make_api(responses: list):
     mock_session = MagicMock()
     # Each call to session.post returns the next response in the list.
     mock_session.post.side_effect = [
-        SimpleNamespace(raise_for_status=lambda: None, json=lambda: r)
-        for r in responses
+        SimpleNamespace(raise_for_status=lambda: None, json=lambda r=r: r) for r in responses
     ]
     api.session = mock_session
     api.base_url = "http://test"

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -9,17 +9,19 @@ git repo.
 
 from __future__ import annotations
 
+import logging
 import subprocess
 import threading
 import time
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from overmind.optimizer import (
     OptimizerAPI,
     _new_traceparent,
     _runtime_metadata,
     _start_heartbeat_thread,
+    poll_once,
     run_command,
 )
 
@@ -53,6 +55,65 @@ def test_run_command_success_round_trip():
 def test_run_command_failure_reports_exit_code_and_stderr():
     ok, result, error = run_command({"command": "echo boom >&2; exit 3", "timeout": 10})
     assert not ok and result["exit_code"] == 3 and "boom" in error, (ok, result, error)
+
+
+def test_run_command_platform_env_overrides_stale_local_key(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "local-secret")
+    ok, result, error = run_command({
+        "command": 'printf \'%s|%s\' "$OPENROUTER_MODEL" "$OPENROUTER_API_KEY"',
+        "timeout": 10,
+        "environment": {
+            "OPENROUTER_MODEL": "openai/gpt-5",
+            "OPENROUTER_API_KEY": "server-secret",
+        },
+    })
+    assert ok, (result, error)
+    assert result["output"] == "openai/gpt-5|[REDACTED]"
+    assert "server-secret" not in result["output"]
+
+
+def test_run_command_redacts_injected_secret_from_stderr_and_debug_logs(caplog):
+    with caplog.at_level(logging.DEBUG, logger="optimizer.client"):
+        ok, result, error = run_command({
+            "command": 'printf \'model=%s key=%s\\n\' "$OPENROUTER_MODEL" "$OPENROUTER_API_KEY" >&2; exit 1',
+            "timeout": 10,
+            "environment": {
+                "OPENROUTER_MODEL": "openai/gpt-5",
+                "OPENROUTER_API_KEY": "server-secret",
+            },
+        })
+    assert not ok
+    assert result["output"] == ""
+    assert error == "model=openai/gpt-5 key=[REDACTED]\n"
+    assert "server-secret" not in caplog.text
+    assert "openai/gpt-5" in caplog.text
+
+
+def test_run_command_local_env_keeps_local_key(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "local-secret")
+    ok, result, error = run_command({
+        "command": 'printf \'%s|%s\' "$OPENROUTER_MODEL" "$OPENROUTER_API_KEY"',
+        "timeout": 10,
+        "environment": {"OPENROUTER_MODEL": "openai/gpt-5"},
+    })
+    assert ok, (result, error)
+    assert result["output"] == "openai/gpt-5|[REDACTED]"
+    assert "local-secret" not in result["output"]
+
+
+def test_run_command_explicit_empty_key_overrides_local_key(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "local-secret")
+    ok, result, error = run_command({
+        "command": 'printf \'%s|%s\' "$OPENROUTER_MODEL" "$OPENROUTER_API_KEY"',
+        "timeout": 10,
+        "environment": {
+            "OPENROUTER_MODEL": "openai/gpt-5",
+            "OPENROUTER_API_KEY": "",
+        },
+    })
+    assert ok, (result, error)
+    assert result["output"] == "openai/gpt-5|"
+    assert "local-secret" not in result["output"]
 
 
 # ── OptimizerAPI.poll sends lease flag ───────────────────────────────────────
@@ -94,6 +155,13 @@ def test_poll_default_lease_is_true():
     api.poll("sess-1")
     _, kwargs = api.session.post.call_args
     assert kwargs["json"]["lease"] is True
+
+
+def test_register_payload_uses_package_version():
+    api = _make_api([{"id": "sess-1"}])
+    assert api.register() == "sess-1"
+    _, kwargs = api.session.post.call_args
+    assert kwargs["json"]["cli_version"] == "optimizer/0.1.58"
 
 
 # ── heartbeat thread calls poll(lease=False) while main loop is busy ─────────
@@ -207,3 +275,31 @@ def test_setup_candidate_branch_idempotent_on_restart(tmp_path):
     _setup_candidate_branch(base_ref, "cand-r", patch, tmp_path)
     content = (tmp_path / "agent.py").read_text()
     assert "restarted" in content, content
+
+
+def test_optimizer_base_ref_strips_candidate_commit_after_restart(tmp_path):
+    from overmind.optimizer import _optimizer_base_ref, _setup_candidate_branch
+
+    _init_git_repo(tmp_path)
+    main_sha = subprocess.run(
+        ["git", "rev-parse", "main"], cwd=tmp_path, check=True, capture_output=True, text=True
+    ).stdout.strip()
+    patch = _make_patch("PROMPT = 'v0'", "PROMPT = 'candidate-a'")
+    _setup_candidate_branch("main", "candidate-a", patch, tmp_path)
+
+    assert _optimizer_base_ref(tmp_path) == main_sha
+
+
+def test_poll_once_runs_smoke_from_base_after_candidate_checkout(tmp_path):
+    from overmind.optimizer import _setup_candidate_branch
+
+    _init_git_repo(tmp_path)
+    patch = _make_patch("PROMPT = 'v0'", "PROMPT = 'candidate-a'")
+    _setup_candidate_branch("main", "candidate-a", patch, tmp_path)
+
+    api = MagicMock()
+    api.poll.return_value = [{"id": "smoke", "candidate_id": "", "command": "cat agent.py", "timeout": 10}]
+
+    assert poll_once(api, "session", tmp_path, base_ref="main") == 1
+    assert api.submit_result.call_args.kwargs["success"] is True
+    assert api.submit_result.call_args.kwargs["result"]["output"] == "PROMPT = 'v0'\n"

--- a/uv.lock
+++ b/uv.lock
@@ -479,7 +479,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1544,7 +1544,7 @@ wheels = [
 
 [[package]]
 name = "overmind"
-version = "0.1.56"
+version = "0.1.58"
 source = { editable = "." }
 dependencies = [
     { name = "litellm" },


### PR DESCRIPTION
## Summary

Companion PR to overmind-core/platform#560 (**agent model alias routing** + **optimiser model comparison**). The server side of that PR attaches new per-command data the executioner (`overmind optimise` daemon) didn't yet understand — landing the server change without this one leaves model comparison live in the API but unusable end-to-end.

- **Per-command `environment` map** — the server attaches a per-command `environment` block carrying the comparison model (`OPENROUTER_MODEL`); the executioner merges these on top of `os.environ` for the subprocess. The server never sends keys. A *missing* key keeps the local value: platform (Overmind credits) runs authenticate with the daemon's own `OVERMIND_API_KEY` / `OVERMIND_API_URL` (the same env the daemon already polls the API with), and `openRouterSource: "local"` runs preserve the user's own `.env` `OPENROUTER_API_KEY`.
- **Secret redaction** — command env keys matching `KEY` / `TOKEN` / `SECRET` / `PASSWORD`, plus the inherited local `OPENROUTER_API_KEY`, are replaced with `[REDACTED]` in command-string debug logs and in stdout/stderr before they are tailed and uploaded. Stderr is redacted too, so a failing command that echoes the key can no longer leak it.
- **Smoke runs against `base_ref`** — the smoke batch (commands with empty `candidate_id`) was running on whatever branch the previous candidate checkout left behind, silently invalidating the baseline. The smoke branch now does a non-forced `git checkout base_ref` before running; local tracked edits fail safely with a real error rather than getting discarded.
- **Base-ref walks past candidate commits on restart** — `_current_branch` returned the last candidate branch after a restart. Replaced with a walker that steps back through any commits whose subject starts with `apply patch for candidate …`, so every candidate branches from the same clean base after a daemon restart.
- **`cli_version` heartbeat uses the package version** — was hardcoded `"optimizer/0.1"`, now `f"optimizer/{__version__}"`. Server can warn about out-of-date executioners and attribute which client ran each experiment.
- **Version bump** — `0.1.57` → `0.1.58`.

## Follow-up (5894206)

`5894206` aligns the env contract with the platform's BYOK removal: the server now sends only `OPENROUTER_MODEL` per command and never injects `OPENROUTER_API_KEY`. The injected-key and explicit-empty-override test scenarios are gone; the redaction tests now cover the daemon's own local key (the only key that exists in the subprocess env today).

## Test plan

- [x] `uv run pytest tests/test_optimizer.py` — 17 passed
- [x] `uv run pytest` (full suite) — 172 passed, 1 skipped
- [x] pre-commit clean

Depends on / pairs with: overmind-core/platform#560
