### PR TITLE
fix(tracing): observe_safe parity with observe

### DIFF
--- a/overmind/__init__.py
+++ b/overmind/__init__.py
@@ -6,7 +6,7 @@ Overmind: automatic observability for LLM applications.
 
 """
 
-__version__ = "0.1.58"
+__version__ = "0.1.60"
 
 from opentelemetry.overmind.prompt import PromptString
 
@@ -21,6 +21,7 @@ from .tracing import (
     get_tracer,
     init,
     observe,
+    observe_safe,
     retrieval,
     set_agent_id,
     set_agent_name,
@@ -48,6 +49,7 @@ __all__ = [
     "get_tracer",
     "init",
     "observe",
+    "observe_safe",
     "retrieval",
     "set_agent_id",
     "set_agent_name",

--- a/overmind/tracing.py
+++ b/overmind/tracing.py
@@ -622,9 +622,11 @@ def observe(
     type: SpanType = SpanType.FUNCTION,
     agent_id: str | None = None,
     project_id: str | None = None,
+    _capture_io: bool = True,
 ) -> Callable[[Callable], Callable]:
     """Decorator (sync or async) that traces a function: captures ``inputs`` /
-    ``outputs`` and stamps canonical span type / status / duration."""
+    ``outputs`` and stamps canonical span type / status / duration. Set
+    ``_capture_io=False`` to skip input/output capture (see ``observe_safe``)."""
 
     def decorator(func: Callable) -> Callable:
         name = span_name or func.__name__
@@ -642,7 +644,8 @@ def observe(
                         otel_span.set_attribute(attrs.AGENT_ID, agent_id)
                     if type == SpanType.TOOL:
                         _stamp_tool_metadata(otel_span, name, func, args, kwargs)
-                    _capture_inputs(otel_span, func, args, kwargs)
+                    if _capture_io:
+                        _capture_inputs(otel_span, func, args, kwargs)
                     start = time.monotonic()
                     try:
                         result = await func(*args, **kwargs)
@@ -651,7 +654,8 @@ def observe(
                             otel_span.set_attribute(attrs.TOOL_ERROR, exc.__class__.__name__)
                         _finalize_span(otel_span, exc, start)
                         raise
-                    _capture_output(otel_span, result)
+                    if _capture_io:
+                        _capture_output(otel_span, result)
                     _finalize_span(otel_span, None, start)
                     return result
 
@@ -668,7 +672,8 @@ def observe(
                     otel_span.set_attribute(attrs.AGENT_ID, agent_id)
                 if type == SpanType.TOOL:
                     _stamp_tool_metadata(otel_span, name, func, args, kwargs)
-                _capture_inputs(otel_span, func, args, kwargs)
+                if _capture_io:
+                    _capture_inputs(otel_span, func, args, kwargs)
                 start = time.monotonic()
                 try:
                     result = func(*args, **kwargs)
@@ -677,7 +682,8 @@ def observe(
                         otel_span.set_attribute(attrs.TOOL_ERROR, exc.__class__.__name__)
                     _finalize_span(otel_span, exc, start)
                     raise
-                _capture_output(otel_span, result)
+                if _capture_io:
+                    _capture_output(otel_span, result)
                 _finalize_span(otel_span, None, start)
                 return result
 
@@ -798,23 +804,18 @@ def observe_safe(
     agent_id: str | None = None,
 ) -> Callable[[F], F]:
     """Like :func:`observe` but never captures arguments or return values;
-    use :func:`set_tag` inside the function for specific metadata."""
+    use :func:`set_tag` inside the function for specific metadata.
 
-    def decorator(func: F) -> F:
-        name = span_name or func.__name__
-
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            with start_child_span(name, span_type=type) as otel_span:
-                if project_id:
-                    otel_span.set_attribute(attrs.PROJECT_ID, project_id)
-                if agent_id:
-                    otel_span.set_attribute(attrs.AGENT_ID, agent_id)
-                return func(*args, **kwargs)
-
-        return wrapper  # type: ignore[return-value]
-
-    return decorator
+    Manual escape hatch for code that handles credentials (API keys, auth
+    tokens, passwords); prefer masking values before they reach traced
+    functions over dropping input/output capture."""
+    return observe(
+        span_name=span_name,
+        type=type,
+        agent_id=agent_id,
+        project_id=project_id,
+        _capture_io=False,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ name = "overmind"
 readme = "README.md"
 requires-python = ">=3.10,<4" # todo; remove the upper bound
 urls = { Homepage = "https://github.com/overmind-core/overmind", Repository = "https://github.com/overmind-core/overmind" }
-version = "0.1.59"
+version = "0.1.60"
 
 
     [project.scripts]

--- a/skills/overmind-agent-telemetry/references/instrumentation.md
+++ b/skills/overmind-agent-telemetry/references/instrumentation.md
@@ -33,7 +33,7 @@ calling it done:
 | Agent name | `agent_name=` in `init()`, `OVERMIND_AGENT_NAME`, or `set_agent_name()` — pick one constant string; the server slugifies it into the agent's identity, so renaming forks a new agent | Traces group under one agent in the Console |
 | Model + token usage | Automatic via provider auto-instrumentation (Step 4); raw-OTel spans should carry `gen_ai.request.model` / `gen_ai.usage.*` | Cost is computed server-side from these |
 | Inputs and outputs | The decorators (Step 5) capture call args and return values automatically; make sure the entry point and key steps are decorated so the trace shows what the agent saw and produced | A trace without I/O can't be debugged or turned into eval data |
-| Sensitive data excluded | Use `@observe_safe()` on functions whose args/returns hold secrets or PII — it traces timing/status without capturing values | Inputs/outputs are stored verbatim |
+| Sensitive data excluded | Not for agents — trace normally and mask credential fields (API keys, tokens, passwords) before they reach decorated functions. `@observe_safe()` (traces timing/status, no values) is a manual escape hatch for human implementation only | Inputs/outputs are stored verbatim |
 | Session grouping | `set_conversation_id(...)` per conversation/thread (stamped as `conversation.id`) whenever the app has multi-turn interactions | Groups traces into Sessions in the Console |
 | User attribution | `set_user(user_id, email=...)` where the app has accounts | Per-user filtering and cost attribution |
 | Span hierarchy + types | One `@entry_point` at the top; `@workflow` / `@tool` / `@retrieval` for the steps under it, with descriptive names | Shows which step failed or was slow, instead of one flat LLM call |
@@ -239,5 +239,5 @@ If nothing shows up:
 | `overmind.init()` on top of an existing `TracerProvider` | OTel keeps the first provider; Overmind attaches nothing | Fan-out path (Step 3b) |
 | Agent name varies per run/env | Each variant becomes a separate agent | One constant `agent_name`, set once |
 | Only auto-instrumentation, no decorators | Flat traces with no inputs/outputs and no step structure | Decorate the entry point and key steps (Step 5) |
-| Secrets or PII in decorated function args | Stored verbatim in the trace | `@observe_safe()` on those functions, or mask before passing |
+| Credentials (API keys, tokens, passwords) in decorated function args | Stored verbatim in the trace | Mask them before passing; `@observe_safe()` only as a manual, human-maintained escape hatch — never preemptively for data that might be sensitive |
 | No `set_conversation_id` in a chat app | Sessions view stays empty | Stamp the thread/conversation id per request |

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -141,10 +141,12 @@ def test_poll_default_lease_is_true():
 
 
 def test_register_payload_uses_package_version():
+    from overmind import __version__
+
     api = _make_api([{"id": "sess-1"}])
     assert api.register() == "sess-1"
     _, kwargs = api.session.post.call_args
-    assert kwargs["json"]["cli_version"] == "optimizer/0.1.58"
+    assert kwargs["json"]["cli_version"] == f"optimizer/{__version__}"
 
 
 # ── heartbeat thread calls poll(lease=False) while main loop is busy ─────────

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from opentelemetry.trace import StatusCode
 
-from overmind.tracing import observe
+from overmind.tracing import SpanType, observe, observe_safe
 
 
 @pytest.fixture(autouse=True)
@@ -341,3 +341,89 @@ def test_observe_async_class_method(mock_tracer):
 
         assert result == 30
         mock_tracer_obj.start_as_current_span.assert_called_once()
+
+
+def test_observe_safe_does_not_capture_io(mock_tracer):
+    """observe_safe never captures inputs/outputs."""
+
+    mock_tracer_obj, mock_span = mock_tracer
+
+    with patch("overmind.tracing.get_tracer", return_value=mock_tracer_obj):
+
+        @observe_safe()
+        def secure_func(api_key: str, payload: dict):
+            return {"ok": True}
+
+        result = secure_func("sk-secret", {"a": 1})
+
+        assert result == {"ok": True}
+        mock_tracer_obj.start_as_current_span.assert_called_once_with("secure_func")
+        assert mock_span.set_status.call_args[0][0].status_code == StatusCode.OK
+        io_calls = [c for c in mock_span.set_attribute.call_args_list if "inputs" in str(c) or "outputs" in str(c)]
+        assert io_calls == []
+
+
+def test_observe_safe_async(mock_tracer):
+    """observe_safe supports async functions and spans the real execution."""
+    import asyncio
+
+    mock_tracer_obj, mock_span = mock_tracer
+
+    with patch("overmind.tracing.get_tracer", return_value=mock_tracer_obj):
+
+        @observe_safe(span_name="secure_async")
+        async def async_fetch(token: str):
+            await asyncio.sleep(0.01)
+            return "data"
+
+        assert asyncio.run(async_fetch("t0ken")) == "data"
+        mock_tracer_obj.start_as_current_span.assert_called_once_with("secure_async")
+        assert mock_span.set_status.call_args[0][0].status_code == StatusCode.OK
+
+
+def test_observe_safe_async_exception_is_recorded(mock_tracer):
+    """Async exceptions mark the span failed (regression: the old sync-only
+    wrapper finalised the span before the coroutine ran)."""
+    import asyncio
+
+    mock_tracer_obj, mock_span = mock_tracer
+
+    with patch("overmind.tracing.get_tracer", return_value=mock_tracer_obj):
+
+        @observe_safe()
+        async def async_fail(token: str):
+            await asyncio.sleep(0.01)
+            raise RuntimeError("secure failure")
+
+        with pytest.raises(RuntimeError, match="secure failure"):
+            asyncio.run(async_fail("t0ken"))
+
+        mock_span.record_exception.assert_called_once()
+        status_calls = list(mock_span.set_status.call_args_list)
+        assert status_calls[-1][0][0].status_code == StatusCode.ERROR
+
+
+def test_observe_safe_tool_metadata(mock_tracer):
+    """observe_safe stamps tool metadata for SpanType.TOOL spans."""
+    from overmind.attrs import TOOL_ARG_KEYS, TOOL_NAME
+
+    mock_tracer_obj, mock_span = mock_tracer
+
+    with patch("overmind.tracing.get_tracer", return_value=mock_tracer_obj):
+
+        @observe_safe(type=SpanType.TOOL)
+        def my_tool(secret: str, query: str):
+            return "ok"
+
+        my_tool("hunter2", "find things")
+
+        set_attrs = {c[0][0]: c[0][1] for c in mock_span.set_attribute.call_args_list}
+        assert set_attrs.get(TOOL_NAME) == "my_tool"
+        assert set_attrs.get(TOOL_ARG_KEYS) == ["secret", "query"]
+
+
+def test_observe_safe_exported_from_package():
+    """observe_safe is importable from the package root."""
+    from overmind import observe_safe
+
+    assert callable(observe_safe)


### PR DESCRIPTION
## observe_safe parity with observe

`observe_safe` was a half-built copy of `observe` — sync-only, no tool metadata, unexported.

### Fix
- `observe` gains private `_capture_io` flag; `observe_safe` now delegates to it with `_capture_io=False`
- Inherits for free: async support, TOOL metadata (`tool.name`/`tool.arg_keys`/`tool.error`), error handling, same span path
- Exported from `overmind/__init__.py` (`@overmind.observe_safe()` now works)

### Before → after

| | Before | After |
|---|---|---|
| async funcs | span closed before coroutine ran | spans real execution |
| `SpanType.TOOL` | no metadata | full tool attrs |
| `from overmind import observe_safe` | ImportError | works |
| `inputs`/`outputs` capture | never (correct) | still never |

### Skill docs
Agents over-applied `observe_safe()` to any "PII" risk, dropping most trace I/O. Reframed as manual human-only escape hatch: agents trace normally and mask credentials instead.

### Version

Bumped `__version__` to `0.1.60` (matches `pyproject.toml`).

### Tests
5 new in `tests/test_tracer.py` (sync no-I/O, async, async-exception regression, TOOL metadata, package import). 177 passed.
