### PR TITLE
Add Overmind platform MCP to the Cursor plugin

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "overmind",
-  "description": "Skills for working with Overmind — agent observability, tracing, and optimization.",
-  "version": "1.1.0",
+  "description": "Overmind skills — agent observability, tracing, and platform workflows for coding agents.",
+  "version": "1.2.0",
   "author": {
     "name": "Overmind",
     "email": "hello@overmindlab.ai"
@@ -15,6 +15,7 @@
     "observability",
     "tracing",
     "agent",
-    "optimization"
+    "optimization",
+    "mcp"
   ]
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "overmind",
   "displayName": "Overmind",
-  "version": "1.1.0",
-  "description": "Skills for working with Overmind — agent observability, tracing, and optimization.",
+  "version": "1.2.0",
+  "description": "Overmind skills and MCP — agent observability, tracing, and platform tools for coding agents.",
   "author": {
     "name": "Overmind",
     "email": "hello@overmindlab.ai"
@@ -16,8 +16,21 @@
     "observability",
     "tracing",
     "agent",
-    "optimization"
+    "optimization",
+    "mcp"
   ],
   "category": "developer-tools",
-  "skills": "./skills/"
+  "skills": "./skills/",
+  "mcpServers": "./mcp.json",
+  "variables": {
+    "type": "object",
+    "properties": {
+      "OVERMIND_API_KEY": {
+        "type": "string",
+        "title": "Overmind API key",
+        "description": "Project API key from Console (Projects → API keys). Used for MCP and tracing ingest."
+      }
+    },
+    "required": ["OVERMIND_API_KEY"]
+  }
 }

--- a/README.md
+++ b/README.md
@@ -45,17 +45,14 @@ Available decorators/helpers: `entry_point`, `workflow`, `tool`, `function`, plu
 
 Use these from Cursor, Codex, or Claude Code to scaffold agents and configure telemetry without leaving your coding environment. Skills live at the repo-root [`skills/`](./skills/) directory so agent installers can pick them up from this repository (e.g. `npx skills add overmind-core/overmind`).
 
-This repo is also a [Cursor plugin](https://cursor.com/docs/plugins) (see [`.cursor-plugin/`](./.cursor-plugin/) and [`mcp.json`](./mcp.json)): install it to get skills plus a remote Overmind MCP server. Set **OVERMIND_API_KEY** when prompted (project API key from Console).
-
 ```bash
 overmind skills list --verbose
 overmind skills sync "Overmind Telemetry"   # or: overmind-agent-telemetry
 ```
 
-| Skill                   | What it does                                                                                                       |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `Overmind Telemetry`    | Add tracing, verify traces via the REST API, and look up current Overmind docs (`overmind-agent-telemetry`).       |
-| `Overmind platform MCP` | Use Overmind MCP tools from a coding agent — agents, traces, datasets, evals, finetunes (`overmind-platform-mcp`). |
+| Skill                | What it does                                                                                                 |
+| -------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `Overmind Telemetry` | Add tracing, verify traces via the REST API, and look up current Overmind docs (`overmind-agent-telemetry`). |
 
 ## CLI reference
 

--- a/README.md
+++ b/README.md
@@ -45,14 +45,17 @@ Available decorators/helpers: `entry_point`, `workflow`, `tool`, `function`, plu
 
 Use these from Cursor, Codex, or Claude Code to scaffold agents and configure telemetry without leaving your coding environment. Skills live at the repo-root [`skills/`](./skills/) directory so agent installers can pick them up from this repository (e.g. `npx skills add overmind-core/overmind`).
 
+This repo is also a [Cursor plugin](https://cursor.com/docs/plugins) (see [`.cursor-plugin/`](./.cursor-plugin/) and [`mcp.json`](./mcp.json)): install it to get skills plus a remote Overmind MCP server. Set **OVERMIND_API_KEY** when prompted (project API key from Console).
+
 ```bash
 overmind skills list --verbose
 overmind skills sync "Overmind Telemetry"   # or: overmind-agent-telemetry
 ```
 
-| Skill                | What it does                                                                                                 |
-| -------------------- | ------------------------------------------------------------------------------------------------------------ |
-| `Overmind Telemetry` | Add tracing, verify traces via the REST API, and look up current Overmind docs (`overmind-agent-telemetry`). |
+| Skill                   | What it does                                                                                                       |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `Overmind Telemetry`    | Add tracing, verify traces via the REST API, and look up current Overmind docs (`overmind-agent-telemetry`).       |
+| `Overmind platform MCP` | Use Overmind MCP tools from a coding agent — agents, traces, datasets, evals, finetunes (`overmind-platform-mcp`). |
 
 ## CLI reference
 

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "overmind": {
+      "url": "https://api.overmindlab.ai/api/mcp/",
+      "headers": {
+        "X-Api-Key": "${OVERMIND_API_KEY}"
+      }
+    }
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ name = "overmind"
 readme = "README.md"
 requires-python = ">=3.10,<4" # todo; remove the upper bound
 urls = { Homepage = "https://github.com/overmind-core/overmind", Repository = "https://github.com/overmind-core/overmind" }
-version = "0.1.60"
+version = "0.1.61"
 
 
     [project.scripts]

--- a/skills/overmind-platform-mcp/SKILL.md
+++ b/skills/overmind-platform-mcp/SKILL.md
@@ -1,0 +1,42 @@
+______________________________________________________________________
+
+## name: overmind-platform-mcp description: Use the Overmind platform MCP to inspect and act on a project from a coding agent — agents, traces, datasets, evals, finetunes, deployments. Use when the user wants to query or change Overmind via MCP tools, or when Overmind MCP tools are available.
+
+# Overmind platform MCP
+
+The Overmind Cursor plugin registers a remote MCP server at
+`https://api.overmindlab.ai/api/mcp/` (Streamable HTTP). Authenticate with a
+project API key (`X-Api-Key`). The key is pinned to one project and has full
+read and write access to that project's tools.
+
+## Setup
+
+1. Create a project API key in Console → Projects → API keys.
+1. Install this plugin (or add the MCP server manually).
+1. Set **OVERMIND_API_KEY** in the plugin Configure panel (or your agent's MCP
+   headers). Never paste the raw key into chat.
+
+Local / self-hosted: point the MCP URL at `{API_BASE}/api/mcp/` instead of
+production.
+
+## How to use
+
+Prefer MCP tools over inventing REST calls when the tools cover the job.
+
+Typical flows:
+
+| Goal                      | Start with                                                             |
+| ------------------------- | ---------------------------------------------------------------------- |
+| See what's in the project | `list_agents`, `list_datasets`, `list_eval_runs`, `list_finetune_jobs` |
+| Diagnose failures         | `agent_failures`, `graph_search`, `list_traces` / `get_trace`          |
+| Launch training           | `finetune_prerequisites` then `create_finetune_job`                    |
+| Run evals                 | `create_eval_run` (after listing datasets / eval sets)                 |
+
+Do not call chat-UI-only helpers — they are not exposed on MCP
+(`propose_plan`, `suggest_navigation`).
+
+## Related
+
+- Telemetry / REST ingest and verification:
+  [overmind-agent-telemetry](../overmind-agent-telemetry/SKILL.md)
+- Docs index: https://docs.overmindlab.ai/llms.txt


### PR DESCRIPTION
## Summary
- Extend the existing Cursor plugin ([docs](https://cursor.com/docs/plugins)) with `mcp.json` pointing at `https://api.overmindlab.ai/api/mcp/`, authenticated via `${OVERMIND_API_KEY}` (plugin variable).
- Bump plugin to **1.2.0**; declare the API key under `variables` in `.cursor-plugin/plugin.json`.
- Add `overmind-platform-mcp` skill and README notes for install/configure.

## Test plan
- [ ] Symlink or copy plugin into `~/.cursor/plugins/local/overmind`, reload Cursor
- [ ] Configure `OVERMIND_API_KEY` with a project key from Console
- [ ] Confirm MCP tools appear (e.g. `list_agents`, `create_finetune_job`)
- [ ] Call a read tool and a write tool against a real project
