### PR TITLE
feat(optimizer): report node/go/cargo runtime metadata

### DIFF
--- a/overmind/optimizer.py
+++ b/overmind/optimizer.py
@@ -205,10 +205,12 @@ def _runtime_metadata() -> dict:
 
     The server stores these on the session and should prefer ``uv`` only when
     ``uv.exists`` is true (and fall back to ``python.executable`` otherwise).
+    Non-Python toolchains (node/go/cargo) are reported the same way so codegen
+    can pick a language-appropriate invoke form.
     """
     uv_path = shutil.which("uv")
     python_on_path = shutil.which("python3") or shutil.which("python")
-    return {
+    meta = {
         "python.version": sys.version,
         "python.version_info": (f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"),
         "python.executable": sys.executable,
@@ -217,6 +219,12 @@ def _runtime_metadata() -> dict:
         "uv.path": uv_path,
         "uv.version": _tool_version(uv_path) if uv_path else None,
     }
+    for tool in ("node", "npx", "pnpm", "bun", "go", "cargo", "rustc"):
+        path = shutil.which(tool)
+        meta[f"{tool}.exists"] = path is not None
+        meta[f"{tool}.path"] = path
+        meta[f"{tool}.version"] = _tool_version(path) if path else None
+    return meta
 
 
 def _new_traceparent() -> tuple[str, str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ name = "overmind"
 readme = "README.md"
 requires-python = ">=3.10,<4" # todo; remove the upper bound
 urls = { Homepage = "https://github.com/overmind-core/overmind", Repository = "https://github.com/overmind-core/overmind" }
-version = "0.1.63"
+version = "0.1.64"
 
 
     [project.scripts]

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -39,6 +39,17 @@ def test_runtime_metadata_reports_python_and_uv():
         assert meta["uv.version"] is None
 
 
+def test_runtime_metadata_reports_extra_toolchains():
+    meta = _runtime_metadata()
+    for tool in ("node", "npx", "pnpm", "bun", "go", "cargo", "rustc"):
+        assert isinstance(meta[f"{tool}.exists"], bool)
+        if meta[f"{tool}.exists"]:
+            assert meta[f"{tool}.path"]
+        else:
+            assert meta[f"{tool}.path"] is None
+            assert meta[f"{tool}.version"] is None
+
+
 def test_traceparent_shape():
     header, trace_id = _new_traceparent()
     assert header == f"00-{trace_id}-{header.split('-')[2]}-01", header

--- a/uv.lock
+++ b/uv.lock
@@ -1544,7 +1544,7 @@ wheels = [
 
 [[package]]
 name = "overmind"
-version = "0.1.63"
+version = "0.1.64"
 source = { editable = "." }
 dependencies = [
     { name = "litellm" },


### PR DESCRIPTION
## Summary
- Companion to the platform language-agnostic optimizer PR: claw now reports non-Python toolchain availability in the optimise register payload.
- Extends `_runtime_metadata()` to probe `node`, `npx`, `pnpm`, `bun`, `go`, `cargo`, and `rustc` (exists/path/version), matching the existing python/uv shape so the platform can generate language-appropriate smoke commands.

## Test plan
- [ ] Run targeted unit tests:
  ```bash
  python -m pytest tests/test_optimizer.py::test_runtime_metadata_reports_python_and_uv tests/test_optimizer.py::test_runtime_metadata_reports_extra_toolchains -q
  ```
- [ ] Confirm both tests pass (python/uv keys unchanged; new toolchain keys present with bool `exists` and null path/version when missing).
- [ ] Manually run `overmind optimise` (or the register path that includes runtime metadata) against a machine with at least one of node/go/cargo installed.
- [ ] Inspect the register payload / session runtime metadata and verify new keys appear, e.g. `node.exists`, `node.path`, `node.version`, `go.exists`, `cargo.exists`, `rustc.exists` (and siblings for npx/pnpm/bun).
- [ ] On a machine missing a given tool, confirm `*.exists` is `false` and `*.path` / `*.version` are `null`.
- [ ] Confirm unrelated untracked `overmind/skills/` was not included in this change.

