### PR TITLE
fix(init): write Claude Code MCP config to project-root .mcp.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,9 +163,24 @@ overmind skills sync overmind
 overmind init --ide codex
 ```
 
-Codex setup writes `.codex/config.toml`, installs the skill under
-`.agents/skills`, and requires `OVERMIND_API_KEY` in the environment. Codex
-loads project configuration only for trusted repositories.
+`init` writes each vendor's own project-scoped MCP config, leaving any other
+configured servers untouched:
+
+| `--ide`                  | MCP config           | Skill install      |
+| ------------------------ | -------------------- | ------------------ |
+| `cursor`                 | `.cursor/mcp.json`   | `.cursor/skills`   |
+| `claude` / `claude_code` | `.mcp.json`          | `.claude/skills`   |
+| `opencode`               | `opencode.json`      | `.opencode/skills` |
+| `codex`                  | `.codex/config.toml` | `.agents/skills`   |
+
+Claude Code reads project MCP servers from a root-level `.mcp.json`; it does not
+read `.claude/mcp.json`. Because `.mcp.json` and `.codex/config.toml` are meant
+to be committed, a key taken from `OVERMIND_API_KEY` is written as a reference
+(`${OVERMIND_API_KEY}` and `env_http_headers` respectively) rather than in plain
+text — pass `--api-key` to write a literal value instead.
+
+Codex setup additionally requires `OVERMIND_API_KEY` in the environment, and
+Codex loads project configuration only for trusted repositories.
 
 | Skill      | What it does                                                                                        |
 | ---------- | --------------------------------------------------------------------------------------------------- |

--- a/overmind/__main__.py
+++ b/overmind/__main__.py
@@ -28,7 +28,7 @@ try:
         configure_logging,
         run_optimizer,
     )
-    from overmind.skills import get_destination_dir, skills_app, sync_skills
+    from overmind.skills import CLAUDE_IDES, get_destination_dir, skills_app, sync_skills
 except ImportError as exc:
     raise ImportError(
         "The Overmind CLI requires the 'cli' extra. Install it with: pip install 'overmind[cli]'"
@@ -100,6 +100,19 @@ MCP_URLS = {
 }
 
 
+def _key_or_env_ref(api_key: str | None, env_ref: str | None) -> str | None:
+    """Substitute ``env_ref`` when the key merely came from ``OVERMIND_API_KEY``.
+
+    Config files like ``.mcp.json`` and ``.codex/config.toml`` are meant to be
+    committed, so prefer an indirect reference over a literal secret. An
+    explicit ``--api-key`` must always win, so only the env-var case is
+    replaced.
+    """
+    if api_key and api_key == os.environ.get("OVERMIND_API_KEY"):
+        return env_ref
+    return api_key
+
+
 def _write_codex_mcp(path: Path, url: str, api_key: str | None = None) -> None:
     auth = (
         'env_http_headers = { "X-Api-Key" = "OVERMIND_API_KEY" }'
@@ -139,10 +152,8 @@ def overmind_init(
         if not os.environ.get("OVERMIND_API_KEY") and not api_key:
             raise typer.BadParameter("set OVERMIND_API_KEY before running init", param_hint="OVERMIND_API_KEY")
         mcp_path = Path.cwd() / ".codex" / "config.toml"
-        # Only fall back to the env var when the key actually came from it; an
-        # explicit --api-key must always win.
-        _write_codex_mcp(mcp_path, url, None if api_key == os.environ.get("OVERMIND_API_KEY") else api_key)
-        console.print(f"overmind MCP server written to {mcp_path}")
+        _write_codex_mcp(mcp_path, url, _key_or_env_ref(api_key, None))
+        console.print(f"overmind MCP server written to {mcp_path.relative_to(Path.cwd())}")
         sync_skills(["overmind"], ide=ide)
         console.print(f"overmind skill installed to {dest}/skills/overmind")
         return
@@ -159,6 +170,18 @@ def overmind_init(
             "enabled": True,
             "headers": {"X-Api-Key": api_key},
         }
+    elif ide in CLAUDE_IDES:
+        # Claude Code reads project MCP servers from a root-level .mcp.json. It
+        # never looks inside .claude/, which holds settings and skills only.
+        mcp_path = Path.cwd() / ".mcp.json"
+        config = json.loads(mcp_path.read_text()) if mcp_path.exists() else {}
+        config.setdefault("mcpServers", {})["overmind"] = {
+            "type": "http",
+            "url": url,
+            # .mcp.json is meant to be committed, so keep the key out of it when
+            # it came from the environment; Claude Code expands ${VAR} at load.
+            "headers": {"X-Api-Key": _key_or_env_ref(api_key, "${OVERMIND_API_KEY}")},
+        }
     else:
         mcp_path = Path.cwd() / dest / "mcp.json"
         config = json.loads(mcp_path.read_text()) if mcp_path.exists() else {}
@@ -169,12 +192,10 @@ def overmind_init(
 
     mcp_path.parent.mkdir(parents=True, exist_ok=True)
     mcp_path.write_text(json.dumps(config, indent=2) + "\n")
-    console.print(f"overmind MCP server written to {mcp_path.name if ide == 'opencode' else f'{dest}/mcp.json'}")
+    console.print(f"overmind MCP server written to {mcp_path.relative_to(Path.cwd())}")
 
     sync_skills(["overmind"], ide=ide)
     console.print(f"overmind skill installed to {dest}/skills/overmind")
-
-    # claude mcp add --transport http corridor https://app.corridor.dev/api/mcp --header "Authorization: Bearer ..."
 
 
 app.command("init")(overmind_init)

--- a/overmind/skills.py
+++ b/overmind/skills.py
@@ -21,6 +21,9 @@ from overmind.skills_db import Skill, skills
 
 console = Console()
 
+# Claude Code accepts several spellings on --ide; they all resolve to `.claude`.
+CLAUDE_IDES = frozenset({"claude", "claude_code", "claude-code"})
+
 # Package dir (`.../site-packages/overmind` or `.../repo/overmind`). Skills live at
 # the repo-root `skills/` for agent installers; the wheel force-includes that
 # tree at `overmind/skills/` so sync still works from an installed package.
@@ -87,7 +90,7 @@ def get_destination_dir(ide: str):
     if ide == "cursor":
         return ".cursor"
 
-    if ide == "claude_code" or ide == "claude" or ide == "claude-code":
+    if ide in CLAUDE_IDES:
         return ".claude"
 
     if ide == "opencode":

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -28,11 +28,48 @@ def test_init_writes_cursor_mcp_json(tmp_path, monkeypatch):
     assert (tmp_path / ".cursor" / "skills" / "overmind" / "SKILL.md").is_file()
 
 
-def test_init_claude_alias_and_opencode_json(tmp_path, monkeypatch):
+def test_init_claude_writes_project_root_mcp_json(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    _init(tmp_path, "claude")
-    assert (tmp_path / ".claude" / "mcp.json").is_file()
+    monkeypatch.delenv("OVERMIND_API_KEY", raising=False)
 
+    for alias in ("claude", "claude_code", "claude-code"):
+        _init(tmp_path, alias)
+
+        # Claude Code reads .mcp.json at the project root, never .claude/mcp.json.
+        cfg = json.loads((tmp_path / ".mcp.json").read_text())
+        assert cfg["mcpServers"]["overmind"] == {
+            "type": "http",
+            "url": "http://localhost:8000/api/mcp/",
+            "headers": {"X-Api-Key": "k"},
+        }
+        assert not (tmp_path / ".claude" / "mcp.json").exists()
+        assert (tmp_path / ".claude" / "skills" / "overmind" / "SKILL.md").is_file()
+
+
+def test_init_claude_preserves_other_servers(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".mcp.json").write_text(json.dumps({"mcpServers": {"other": {"command": "uvx", "args": ["other"]}}}))
+
+    _init(tmp_path, "claude")
+
+    cfg = json.loads((tmp_path / ".mcp.json").read_text())
+    assert cfg["mcpServers"]["other"] == {"command": "uvx", "args": ["other"]}
+    assert "overmind" in cfg["mcpServers"]
+
+
+def test_init_claude_keeps_env_key_out_of_committed_config(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OVERMIND_API_KEY", "secret")
+    result = runner.invoke(app, ["init", "--ide", "claude", "--env", "local"], catch_exceptions=False)
+
+    assert result.exit_code == 0, result.output
+    cfg = json.loads((tmp_path / ".mcp.json").read_text())
+    assert cfg["mcpServers"]["overmind"]["headers"] == {"X-Api-Key": "${OVERMIND_API_KEY}"}
+    assert "secret" not in (tmp_path / ".mcp.json").read_text()
+
+
+def test_init_opencode_json(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     _init(tmp_path, "opencode")
     cfg = json.loads((tmp_path / "opencode.json").read_text())
     assert cfg["mcp"]["overmind"] == {


### PR DESCRIPTION
## Problem

`overmind init --ide claude` (and `--ide claude_code`) wrote the MCP server to `.claude/mcp.json`. Claude Code never reads that path — project-scoped MCP servers live in a root-level `.mcp.json`, and `.claude/` holds settings and skills only.

The command printed `overmind MCP server written to .claude/mcp.json` and exited 0, so the failure was silent. `claude mcp list` showed no `overmind` server, and the skill then told users to re-run `overmind init`, which could never fix it.

Found while setting up Overmind telemetry on a real repo, where init had "succeeded" but no MCP tools were available.

## Fix

- Write `.mcp.json` at the project root for all Claude aliases (`claude`, `claude_code`, `claude-code`), merging into any servers already declared there.
- Include `"type": "http"`, which the current Claude Code schema expects for remote servers.
- `.mcp.json` is meant to be committed, so a key that merely came from `OVERMIND_API_KEY` is now written as `${OVERMIND_API_KEY}` — Claude Code expands it at load. This mirrors the Codex path's existing `env_http_headers` behaviour; both now share one `_key_or_env_ref` helper. An explicit `--api-key` still writes a literal value.
- The "written to" message now prints the real relative path instead of an assumed one.
- Dropped a stale leftover comment and folded the three Claude spellings into `CLAUDE_IDES`.

## Other vendors

Checked each against its current docs. All three were already correct and are unchanged:

| Vendor | MCP config | Status |
| --- | --- | --- |
| Cursor | `.cursor/mcp.json`, `mcpServers`, `url` + `headers` | correct |
| opencode | root `opencode.json`, `mcp` block, `type: remote` | correct |
| Codex | project `.codex/config.toml`, `http_headers` / `env_http_headers` | correct |

Skill install directories (`.cursor/skills`, `.claude/skills`, `.opencode/skills`, `.agents/skills`) are all valid discovery paths for their vendor.

## Verification

- Ran `init` in a scratch directory and confirmed `claude mcp list` picks up the generated `.mcp.json` as a project-scope server.
- Three new tests: the root path plus absence of `.claude/mcp.json` across all three aliases, merge-preserves-other-servers, and the env-key indirection.
- Full suite: 609 passed, 1 skipped. `ruff check` and `ruff format --check` clean on the changed files.

## Not included

`MCP_URLS["staging"]` on `main` points at `https://staging.overmindlab.ai/api/mcp/`, but the endpoint that actually answers is `https://api-staging.overmindlab.ai/api/mcp/`. That is a separate bug and I left it out of this branch. Happy to add it here or send it separately.