### PR TITLE
fix(init): use api-staging host for staging MCP url

### DIFF
--- a/overmind/__main__.py
+++ b/overmind/__main__.py
@@ -93,7 +93,8 @@ app.add_typer(skills_app, name="skills")
 
 
 MCP_URLS = {
-    "staging": "https://staging.overmindlab.ai/api/mcp/",
+    "production": "https://api.overmindlab.ai/api/mcp/",
+    "staging": "https://api-staging.overmindlab.ai/api/mcp/",
     "development": "http://localhost:8000/api/mcp/",
     "local": "http://localhost:8000/api/mcp/",
     "dev": "http://localhost:8000/api/mcp/",


### PR DESCRIPTION
The staging MCP server is at `api-staging.overmindlab.ai`, not `staging.overmindlab.ai`, so `overmind init --env staging` pointed clients at a host that does not serve MCP.

Also adds `production` as an explicit entry in `MCP_URLS` so all environments are listed in one place. The dict lookup still falls back to the production URL for unknown values, so behaviour is unchanged.

Tests: `pytest tests/test_init.py` passes.