### PR TITLE
docs(skill): sync the Overmind skill with the trajectory paradigm

### DIFF
--- a/skills/overmind/SKILL.md
+++ b/skills/overmind/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: overmind
-description: Operate the Overmind platform through its MCP server — add tracing to a Python AI/LLM project, inspect telemetry (traces, sessions, agent health, failures, context graph), upload and clean datasets, author evaluators / eval sets / eval runs, fine-tune models, and launch optimizer experiments. Use when the user mentions Overmind, adding telemetry/observability/tracing, traces landing, finetuning or training a model, uploading datasets, eval runs, evaluators, dataset quality, prompt/agent optimization, or when Overmind MCP tools are available.
+description: Operate the Overmind platform through its MCP server — add tracing to a Python AI/LLM project, inspect telemetry (traces, sessions, task executions, agent health, failures, context graph), upload and clean datasets, author evaluators / eval sets / eval runs, fine-tune models, and launch optimizer experiments. Use when the user mentions Overmind, adding telemetry/observability/tracing, traces landing, finetuning or training a model, uploading datasets, eval runs, evaluators, dataset quality, prompt/agent optimization, or when Overmind MCP tools are available.
 ---
 
 # Overmind platform MCP
@@ -9,9 +9,13 @@ Overmind is an agent observability and optimization platform. It ingests traces
 from LLM agents, turns them into datasets, grades them with evaluators, and
 uses those datasets to fine-tune models and optimize agent prompts/code.
 
-This skill covers the common Overmind workflows: resolving agents,
-telemetry (instrument and inspect traces), datasets, evals, fine-tuning,
-and optimizer experiments.
+Overmind models production work as **Agent > Capabilities > Tasks**: a
+capability is one agent, a task (behaviour) is a scanned contract it
+performs, and a task execution is one carved, scored unit of a real trace.
+
+This skill covers the common Overmind workflows: resolving agents, tasks and
+task executions, telemetry (instrument and inspect traces), datasets, evals,
+fine-tuning, and optimizer experiments.
 
 ## Core principles
 
@@ -59,6 +63,8 @@ Follow these for ALL Overmind MCP work:
 
 - Resolving / updating agents, prompts, eval spec, and GitHub analyze:
   [references/capabilities.md](references/capabilities.md)
+- Tasks (behaviour registry, task executions, eval coverage):
+  [references/behaviours.md](references/behaviours.md)
 - Telemetry (add tracing, inspect traces / sessions / health, connectors):
   [references/telemetry.md](references/telemetry.md)
 - Uploading / building datasets (from traces, failures, or an attached file)
@@ -74,11 +80,12 @@ Follow these for ALL Overmind MCP work:
 
 ## Conventions (read before any workflow)
 
-- **List first.** `list_datasets`, `list_capabilities`, `list_eval_sets`,
-  `list_evaluators`, `list_eval_runs`, `list_finetune_jobs`,
-  `list_deployed_models`, `list_optimizer_experiments`, `list_traces`,
-  `list_sessions`. Then pass `dataset_name`, `eval_set_name`,
-  `evaluator_names`, `capability_name_or_slug`, `eval_run_name`.
+- **List first.** `list_datasets`, `list_capabilities`, `list_behaviours`,
+  `list_task_executions`, `list_eval_sets`, `list_evaluators`,
+  `list_eval_runs`, `list_finetune_jobs`, `list_deployed_models`,
+  `list_optimizer_experiments`, `list_traces`, `list_sessions`. Then pass
+  `dataset_name`, `eval_set_name`, `evaluator_names`,
+  `capability_name_or_slug`, `task`, `eval_run_name`.
   `list_capabilities` / `get_capability` return top-level `id` (bare UUID) and
   `active_model`; `get_capability` also `source_repo` and a capped `flow`
   (`flow_truncated` when clipped).
@@ -126,7 +133,11 @@ a running job is frozen until the job ends.
 Typical loop, always via MCP:
 
 1. **See what's happening** — [telemetry.md](references/telemetry.md)
-   (`capability_health` → `capability_failures` → `list_traces` / `get_trace`).
+   (`capability_health` → `capability_failures` → `list_task_executions` →
+   `list_traces` / `get_trace`). The task-execution layer
+   ([behaviours.md](references/behaviours.md)) sits between the agent and its
+   spans: check it before walking traces by hand, and treat
+   `binding_source: "unbound"` as an instrumentation gap, not a scoring one.
    Resolve / retarget agents via [capabilities.md](references/capabilities.md)
    (`list_capabilities` / `get_capability` / `update_capability`;
    `analyze_github_repo` if none exist). If nothing is landing, add tracing

--- a/skills/overmind/references/behaviours.md
+++ b/skills/overmind/references/behaviours.md
@@ -1,0 +1,76 @@
+# Tasks — behaviour registry, task executions, coverage
+
+Overmind models production work as **Agent > Capabilities > Tasks**. A
+**behaviour** (a "task") is a contract minted from the codebase scan. A
+**task execution** is one carved unit of a real trace — a run or a turn —
+bound to that contract and scored.
+
+This is the layer between an agent and its raw traces. When quality drops,
+read the failing units here before you walk spans in
+[telemetry.md](telemetry.md).
+
+All of this is Overmind MCP. Inspect each tool's schema for arguments.
+
+## Workflow
+
+```
+- [ ] 1. list_behaviours — the task map for the agent (key, grain, entry_anchor, status)
+- [ ] 2. list_task_executions — bound units, newest first; filter by status / binding_source
+- [ ] 3. get_task_execution — route, per-step results, user intent, session rationale
+- [ ] 4. behaviour_coverage — which tasks still have no outcome / step judge
+- [ ] 5. get_behaviour_authoring_context — the contract to write a judge against
+- [ ] 6. list_behaviour_evaluators — the judges already bound to one task
+```
+
+## The registry
+
+`list_behaviours(capability_name_or_slug?, status?, limit?)` — rows carry
+`key` (stable across rescans), `display_name`, `capability`, `entry_anchor`
+(`module.qualname` of the entry symbol), `status` (`active` | `retired`),
+`grain` (`run` | `turn`), and `graph_ref`.
+
+Behaviours come from the scan, not from instrumented code. If a task is
+missing, the repo scan is stale — re-run analyze
+([capabilities.md](capabilities.md)), do not try to create one.
+
+The `key` is the same slug the SDK stamps: `overmind.task(key, unit="turn")`
+and the LangGraph `bind(behaviours={...})` map both take it. See
+[telemetry.md](telemetry.md#step-5--carve-phases-into-turn-units).
+
+## Executions
+
+`list_task_executions(capability_name_or_slug?, task?, trace_id?, conversation_id?, binding_source?, status?, limit?)`
+— one row per carved unit, newest first:
+
+- `status` — `completed` | `error` | `interrupted`. `interrupted` means a
+  rootless trace: the run was killed, or is still in flight past the settle
+  window.
+- `binding_source` — `anchor_join` (matched on the code anchor), `declared`
+  (the SDK stamped the key), or `unbound`.
+- `success_score`, `session_score`, `terminal_kind`, `route_flags`,
+  `duration_ms`, `trace_id`, `conversation_id`, `graph_ref`.
+
+**`unbound` is the first thing to check when scores look empty.** An unbound
+unit was never joined to a contract, so its step judges never ran. The fix is
+instrumentation — decorate the anchor, or stamp the key with
+`overmind.task(...)` ([telemetry.md](telemetry.md)) — not a re-score.
+
+`get_task_execution(task_execution_id)` — the UUID from
+`list_task_executions`. Adds `unit_span_id`, `observed_route`,
+`step_results`, `user_intent`, and `session_rationale`. Drill the raw spans
+with `get_trace(trace_id)`.
+
+## Coverage and authoring
+
+- `behaviour_coverage(capability_name_or_slug)` — per task, which outcome and
+  step judges exist and which contract segments are still uncovered. Start
+  here when the ask is "what is not evaluated".
+- `get_behaviour_authoring_context(task, capability_name_or_slug?)` — the
+  contract to write against: `anchor_sequence`, named `steps` (each with the
+  anchor a step judge binds to), `tool_set`, `terminal`. Call it **before**
+  `create_judge_evaluator` for any step-scoped judge — the `anchor_segment`
+  argument must come from this payload, not from a guess.
+- `list_behaviour_evaluators(task, capability_name_or_slug?)` — the compiled
+  suite already bound to one task (step + outcome). Reuse before authoring.
+
+Authoring itself lives in [evals.md](evals.md).

--- a/skills/overmind/references/capabilities.md
+++ b/skills/overmind/references/capabilities.md
@@ -3,6 +3,10 @@
 Resolve agents with `list_capabilities` / `get_capability`. Stamp the returned `id`
 into the SDK and inspect traces in [telemetry.md](telemetry.md).
 
+Overmind models work as **Agent > Capabilities > Tasks**. This file covers the
+capability. The tasks (behaviours) under it, and their scored executions, live
+in [behaviours.md](behaviours.md).
+
 All of this is Overmind MCP. Inspect each tool's schema for arguments.
 `update_capability` and the GitHub analyze tools are gated (they mutate).
 
@@ -13,8 +17,9 @@ All of this is Overmind MCP. Inspect each tool's schema for arguments.
 - [ ] 2. get_capability — card: id, active_model, source_repo, capped flow
 - [ ] 3. capability_prompts / capability_eval_spec when you need prompt text or the eval contract
 - [ ] 4. update_capability to retarget the live model (or patch description / display_name)
-- [ ] 5. If no agents / no repo: analyze_github_repo or analyze_github_repo_url
-- [ ] 6. assign_traces_to_capability for mis-attributed traces
+- [ ] 5. list_behaviours / behaviour_coverage for the agent's task map ([behaviours.md](behaviours.md))
+- [ ] 6. If no agents / no repo: analyze_github_repo or analyze_github_repo_url
+- [ ] 7. assign_traces_to_capability for mis-attributed traces
 ```
 
 ## Card
@@ -58,6 +63,11 @@ runs in the background — agents and prompts appear when it finishes.
   Overmind GitHub App granted on that repo.
 - Public URL (no connection): `analyze_github_repo_url(url, branch?)`.
   Private repos need the connected-account path.
+
+The scan also mints the capability's **behaviour registry** — the task
+contracts production units bind to. After it finishes, `list_behaviours`
+shows the task map ([behaviours.md](behaviours.md)); a missing task means the
+scan is stale, so re-run analyze rather than trying to create one.
 
 Returns `{queued, repo, branch, status}` — no job id. Wait by
 `list_capabilities` until rows appear. If you already have

--- a/skills/overmind/references/evals.md
+++ b/skills/overmind/references/evals.md
@@ -19,6 +19,7 @@ arguments.
 - [ ] 1. list_datasets — confirm the dataset is eval intent
 - [ ] 2. list_evaluators / list_eval_sets — reuse before creating
          (Default set may already exist from the post-scan preload)
+- [ ] 2b. Task-scoped judge? behaviour_coverage → get_behaviour_authoring_context first
 - [ ] 3. Author: generate_evaluators (agent suite) OR create_judge_evaluator (one judge)
 - [ ] 4. create_eval_set → add_evaluators_to_eval_set → activate_eval_set
 - [ ] 5. create_eval_run (creates AND launches) — MCP is the launch path
@@ -45,6 +46,29 @@ arguments.
   `update_judge_evaluator(evaluator, evaluation_prompt, score_type, …)`.
 - Verify what a judge reads:
   `preview_evaluator_prompt(evaluator, trajectory?, structured?, expected?)`.
+
+### Task-scoped judges (outcome and step)
+
+A judge can bind to one task (behaviour) instead of the whole agent. Do this
+before you call `create_judge_evaluator`:
+
+1. `behaviour_coverage(capability_name_or_slug)` — per task, the outcome and
+   step judges that exist and the contract segments still uncovered. Author
+   against the gaps.
+1. `list_behaviour_evaluators(task, capability_name_or_slug?)` — the suite
+   already bound to that task. Reuse before adding another judge.
+1. `get_behaviour_authoring_context(task, capability_name_or_slug?)` —
+   **required** for a step judge. It returns the contract: `anchor_sequence`,
+   named `steps` with the anchor each step judge binds to, `tool_set`, and
+   `terminal`.
+
+Then pass `task=<behaviour key>`, `behaviour_role="outcome"` (grades the
+deliverable) or `"step"` (grades one segment), and — for `step` — an
+`anchor_segment` copied from the authoring context. Never guess an
+`anchor_segment`: a segment that is not in the contract silently never
+matches, and the judge skips every unit.
+
+Task keys and executions: [behaviours.md](behaviours.md).
 
 ## 2. Group into eval sets
 

--- a/skills/overmind/references/telemetry.md
+++ b/skills/overmind/references/telemetry.md
@@ -20,6 +20,7 @@ Conventions (names not ids, errors-as-values, mutations) live in
 - [ ] 1. capability_health — start here for "how is this agent doing"
 - [ ] 2. If nothing is landing: detect existing OTel, install the SDK, init, decorate (below)
 - [ ] 3. capability_failures if quality is down (do not copy ids into create_dataset_from_traces)
+- [ ] 3b. list_task_executions → get_task_execution — the scored unit layer ([behaviours.md](behaviours.md))
 - [ ] 4. list_traces → get_trace to drill in (use summary for totals, don't sum pages)
 - [ ] 5. list_sessions / get_session when the app is multi-turn
 - [ ] 6. graph_* when the question is lineage / similarity, not a simple list
@@ -57,13 +58,32 @@ When the user wants a dataset from those failures, jump to
 `create_dataset_from_failures` (see [datasets.md](datasets.md)) — do **not**
 copy trace ids from this result into `create_dataset_from_traces`.
 
+## Task executions (the scored unit layer)
+
+A trace is carved into task executions — one per run or turn — and each unit
+is bound to a scanned task contract and scored. Read units before spans:
+
+- `list_task_executions(capability_name_or_slug?, task?, trace_id?, conversation_id?, binding_source?, status?, limit?)`
+  — `status` (`completed` | `error` | `interrupted`), `binding_source`
+  (`anchor_join` | `declared` | `unbound`), `success_score`,
+  `session_score`, `terminal_kind`, `route_flags`.
+- `get_task_execution(task_execution_id)` — route, `step_results`,
+  `user_intent`, `session_rationale`, `unit_span_id`.
+
+`binding_source: "unbound"` means the unit never joined a contract, so its
+step judges never ran. That is an **instrumentation** gap — decorate the
+anchor or stamp `overmind.task(key)` (Step 5 / Step 6 below). Full tool
+reference: [behaviours.md](behaviours.md).
+
 ## Traces
 
 - `list_traces(capability?, search?, status?, model?, min_duration_ms?, max_duration_ms?, start_after?, start_before?, session?, all_spans?, ordering?, limit?, offset?)` — production spans. Default is **root-only**;
   `all_spans=true` includes children (adds `span_id` on rows). Compact
-  rows: `trace_id`, name, capability, status, duration, `total_tokens`,
-  `total_cost`, model, live `trace_scores`, `n_scored`, `any_failed`,
-  `graph_ref`. The `summary` object aggregates the **full** filtered set
+  rows: `trace_id`, name, capability, status, `trace_status`
+  (`completed` | `live` | `interrupted` — `live` is still in flight,
+  `interrupted` is rootless past the settle window; neither is a failure),
+  duration, `total_tokens`, `total_cost`, model, live `trace_scores`,
+  `n_scored`, `any_failed`, `graph_ref`. The `summary` object aggregates the **full** filtered set
   (counts, errors, sum/avg tokens and cost, duration stats) regardless of
   the page returned — answer totals/averages from `summary`; do not paginate
   or sum rows yourself. Paginate (`limit` + `offset`, `has_more`) only when


### PR DESCRIPTION
The platform trajectory PR (overmind-core/platform#649) shipped six MCP tools the skill never mentioned, and changed a payload the skill documents. The SDK half of the skill was already updated in #70; this is the MCP half.

### New reference

`skills/overmind/references/behaviours.md` — the behaviour registry (task contracts minted from the repo scan) and task executions (carved, scored units of a trace). Covers `list_behaviours`, `list_task_executions`, `get_task_execution`, `behaviour_coverage`, `get_behaviour_authoring_context`, `list_behaviour_evaluators`.

The point an agent most needs: `binding_source: "unbound"` means the unit never joined a contract, so its step judges never ran. That is an instrumentation gap, and the fix is to decorate the anchor or stamp `overmind.task(key)` — not to re-score.

### Updated

- **SKILL.md** — names the Agent > Capabilities > Tasks model, links the new reference, adds the new `list_*` tools to the list-first convention, and puts `list_task_executions` into the debug loop between `capability_failures` and `list_traces`.
- **evals.md** — a new "Task-scoped judges" section. `get_behaviour_authoring_context` is required before authoring a step judge, because a guessed `anchor_segment` matches nothing and the judge silently skips every unit.
- **telemetry.md** — documents the `trace_status` field (`completed` | `live` | `interrupted`) that `list_traces` rows gained, and adds the task-execution layer to the workflow.
- **capabilities.md** — points at the task map the repo scan mints.

### Verification

- `uv run pytest tests/test_init.py` passes (skill packaging copies the whole directory, so the new reference ships with no manifest change).
- All relative links across the skill resolve.

Platform-side companion: the duplicate tool registration fix, and the same edits mirrored into the vendored copy at `overmind/skills/`.